### PR TITLE
상하좌우 여백 없는 벡터 리소스로 로고 변경

### DIFF
--- a/android/app/src/main/res/drawable/ic_priceguard_original.xml
+++ b/android/app/src/main/res/drawable/ic_priceguard_original.xml
@@ -1,0 +1,17 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="241.35dp"
+    android:height="297.81dp"
+    android:viewportWidth="241.35"
+    android:viewportHeight="297.81">
+  <path
+      android:pathData="M231.85,38.74a5.99,5.99 0,0 1,5.5 5.97v140.26c0,55.2 -97.49,100.88 -114.24,108.32a5.99,5.99 0,0 1,-4.87 0C101.49,285.86 4,240.18 4,184.98V44.72a5.98,5.98 0,0 1,5.5 -5.97Q75.85,33.42 117.32,5.03a5.94,5.94 0,0 1,6.7 0Q165.49,33.4 231.85,38.74Z"
+      android:strokeWidth="8"
+      android:fillColor="#3a86ff"
+      android:strokeColor="#3a86ff"/>
+  <path
+      android:pathData="M184.68,151.59l-73.97,73.97a10.52,10.52 0,0 1,-14.88 0l-52.05,-52.05a10.52,10.52 0,0 1,0 -14.88l73.97,-73.97a10.54,10.54 0,0 1,5.38 -2.88l65.06,-13.01a10.52,10.52 0,0 1,12.38 12.38l-13.01,65.06A10.54,10.54 0,0 1,184.68 151.59Z"
+      android:fillColor="#ffbe0b"/>
+  <path
+      android:pathData="M173.92,95.43m-8.92,0a8.92,8.92 0,1 1,17.84 0a8.92,8.92 0,1 1,-17.84 0"
+      android:fillColor="#fff"/>
+</vector>

--- a/android/app/src/main/res/layout/activity_intro.xml
+++ b/android/app/src/main/res/layout/activity_intro.xml
@@ -24,10 +24,10 @@
 
         <ImageView
             android:id="@+id/iv_intro_app_logo"
-            android:layout_width="160dp"
-            android:layout_height="160dp"
-            android:layout_marginTop="114dp"
-            android:src="@drawable/ic_priceguard_foreground"
+            android:layout_width="120dp"
+            android:layout_height="150dp"
+            android:layout_marginTop="120dp"
+            android:src="@drawable/ic_priceguard_original"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
@@ -36,6 +36,7 @@
             android:id="@+id/tv_intro_app_title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
             android:text="@string/app_name"
             android:textAppearance="?attr/textAppearanceDisplayMedium"
             app:layout_constraintEnd_toEndOf="parent"

--- a/android/app/src/main/res/layout/activity_login.xml
+++ b/android/app/src/main/res/layout/activity_login.xml
@@ -31,9 +31,10 @@
 
         <ImageView
             android:id="@+id/iv_login_logo"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:src="@drawable/ic_priceguard_foreground"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_marginEnd="16dp"
+            android:src="@drawable/ic_priceguard_original"
             app:layout_constraintBottom_toBottomOf="@+id/tv_login_title"
             app:layout_constraintEnd_toStartOf="@+id/tv_login_title"
             app:layout_constraintHorizontal_chainStyle="packed"
@@ -109,8 +110,8 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:text="@string/login"
             android:onClick="@{() -> viewModel.login()}"
+            android:text="@string/login"
             app:iconGravity="textStart"
             app:layout_constraintEnd_toStartOf="@+id/gl_vertical_end"
             app:layout_constraintHorizontal_chainStyle="packed"


### PR DESCRIPTION

## 진행 내용

- [x] 인트로, 로그인 화면에서 앱 로고 리소스 상하좌우 여백 없는걸로 변경


## 스크린샷 (선택)

<img width="493" alt="image" src="https://github.com/boostcampwm2023/and09-PriceGuard/assets/27392567/4394e425-9e49-4d4a-9a6d-94ef1c913443">
