### PR TITLE
Circular Progress Indicator 색상을 올바른 컬러 코드로 변경

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -2,7 +2,7 @@
 <resources>
 
     <style name="Theme.PriceGuard.CircularProgressIndicator" parent="Widget.Material3.CircularProgressIndicator.ExtraSmall">
-        <item name="indicatorColor">?attr/colorSurface</item>
+        <item name="indicatorColor">?attr/colorOnPrimary</item>
     </style>
 
     <style name="MaterialAlertDialog.App" parent="MaterialAlertDialog.Material3">


### PR DESCRIPTION

## 진행 내용

- [x] Circular Progress Indicator 색상을 올바른 컬러 코드로 변경


## 스크린샷 (선택)

<img width="504" alt="image" src="https://github.com/boostcampwm2023/and09-PriceGuard/assets/27392567/5ee1e740-c19e-44b4-975f-596e33e0edcf">

