### PR TITLE
URL 검사 정규 표현식 수정

### DIFF
--- a/backend/src/product/product.service.ts
+++ b/backend/src/product/product.service.ts
@@ -5,18 +5,17 @@ import { ProductDetailsDto } from 'src/dto/product.details.dto';
 import axios from 'axios';
 import { productInfo11st, xmlConvert11st } from 'src/utils/openapi.11st';
 
-const REGEXP_11ST = /(?:http:\/\/|https:\/\/)?www\.11st\.co\.kr\/products\/[1-9]\d*(?:\/share)?/g;
-
+const REGEXP_11ST = /http[s]?:\/\/(?:www\.|m\.)?11st\.co\.kr\/products\/(?:ma\/|m\/)?([1-9]\d*)(?:\?.*)?(?:\/share)?/;
 @Injectable()
 export class ProductService {
     async verifyUrl(productUrlDto: ProductUrlDto): Promise<ProductDetailsDto> {
         const { productUrl } = productUrlDto;
-        if (!REGEXP_11ST.test(productUrl)) {
+        const matchList = productUrl.match(REGEXP_11ST);
+        if (matchList === null) {
             throw new HttpException('URL이 유효하지 않습니다.', HttpStatus.BAD_REQUEST);
         }
         try {
-            const { pathname } = new URL(productUrl);
-            const code = pathname.split('/')[2];
+            const [, code] = matchList;
             const openApiUrl = productInfo11st(code);
             const xml = await axios.get(openApiUrl, { responseType: 'arraybuffer' });
             const productDetails = xmlConvert11st(xml.data);


### PR DESCRIPTION
## 진행 내용
```
http://m.11st.co.kr/products/ma/3895994773
http://m.11st.co.kr/products/m/5056486187?prdNo=5056486187
http://m.11st.co.kr/products/ma/6174685871?&trTypeCd=MAG3&trCtgrNo=950076
http://www.11st.co.kr/products/ma/6174685871?&trTypeCd=MAG3&trCtgrNo=950076
```
위와 같이 모바일 및 `products/ma/<상품코드>` 로 된 URL은 다 유효하지 않은 URL로 처리해버리는 경우가 있어서 정규표현식을 수정하였습니다.

