### PR TITLE
사용자 추적 상품 전체 목록 조회 API 구현

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -7,7 +7,7 @@ import {
     ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { Controller, Get, HttpStatus, Req, UseFilters, UseGuards } from '@nestjs/common';
-import { AuthExceptionFilter } from 'src/exceptions/auth.exception';
+import { HttpExceptionFilter } from 'src/exceptions/http.exception.filter';
 import { AuthSuccess, ExpiredTokenError, InvalidTokenError, RefreshJWTSuccess } from 'src/dto/auth.swagger.dto';
 import { AuthGuard } from '@nestjs/passport';
 import { AuthService } from './auth.service';
@@ -16,7 +16,7 @@ import { User } from 'src/entities/user.entity';
 
 @ApiTags('auth api')
 @Controller('auth')
-@UseFilters(AuthExceptionFilter)
+@UseFilters(HttpExceptionFilter)
 export class AuthController {
     constructor(private authService: AuthService) {}
 

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -16,7 +16,7 @@ export class AuthService {
 
     async getAccessToken(user: User): Promise<string> {
         return this.jwtService.sign(
-            { email: user.email, name: user.userName },
+            { id: user.id, email: user.email, name: user.userName },
             { secret: ACCESS_TOKEN_SECRETS, expiresIn: '5m' },
         );
     }

--- a/backend/src/auth/jwt/jwt.strategy.ts
+++ b/backend/src/auth/jwt/jwt.strategy.ts
@@ -18,7 +18,7 @@ export class AccessJwtStrategy extends PassportStrategy(Strategy, 'access') {
         if (Date.now() >= payload.exp * 1000) {
             throw new HttpException('토큰이 만료되었습니다.', HttpStatus.GONE);
         }
-        return { email: payload.email, userName: payload.name };
+        return { id: payload.id, email: payload.email, userName: payload.name };
     }
 }
 

--- a/backend/src/dto/product.swagger.dto.ts
+++ b/backend/src/dto/product.swagger.dto.ts
@@ -1,6 +1,7 @@
 import { HttpStatus } from '@nestjs/common';
 import { ApiProperty } from '@nestjs/swagger';
 import { ProductDetailsDto } from './product.details.dto';
+import { TrackingProductDto } from './product.tracking.dto';
 
 export class VerifyUrlSuccess {
     @ApiProperty({
@@ -99,6 +100,28 @@ const productListExample = [
         imageUrl: 'https://cdn.011st.com/11dims/strip/false/11src/asin/B01HZ0YT2C/B.jpg?1700390686058',
     },
 ];
+
+const trackingProductListExample = [
+    {
+        productName: 'Hallmark Keepsake 해리포터 마법의 분류 모자 크리스마스 장식',
+        productCode: '5897533626',
+        shop: '11번가',
+        shopUrl: 'https://www.11st.co.kr/products/6221602897',
+        imageUrl: 'https://cdn.011st.com/11dims/strip/false/11src/asin/B091516D2Z/B.jpg?1700527038699',
+        targetPrice: 30000,
+        price: 20000,
+    },
+    {
+        productName: 'Mercer Culinary 밀레니아 10인치 브레드 나이프 빵 칼 (M23210WBH)',
+        productCode: '3534429539',
+        shop: '11번가',
+        shopUrl: 'https://www.11st.co.kr/products/6221602897',
+        imageUrl: 'https://cdn.011st.com/11dims/strip/false/11src/asin/B01HZ0YT2C/B.jpg?1700390686058',
+        targetPrice: 20000,
+        price: 15000,
+    },
+];
+
 export class GetTrackingListSuccess {
     @ApiProperty({
         example: HttpStatus.OK,
@@ -111,10 +134,10 @@ export class GetTrackingListSuccess {
     })
     message: string;
     @ApiProperty({
-        example: JSON.stringify(productListExample, null, 2),
+        example: JSON.stringify(trackingProductListExample, null, 2),
         description: '상품 목록',
     })
-    trackingList: ProductDetailsDto[];
+    trackingList: TrackingProductDto[];
 }
 
 export class GetRecommendListSuccess {

--- a/backend/src/dto/product.tracking.dto.ts
+++ b/backend/src/dto/product.tracking.dto.ts
@@ -1,0 +1,9 @@
+export class TrackingProductDto {
+    productName: string;
+    productCode: string;
+    shop: string;
+    shopUrl: string;
+    imageUrl: string;
+    targetPrice: number;
+    price: number;
+}

--- a/backend/src/entities/product.entity.ts
+++ b/backend/src/entities/product.entity.ts
@@ -16,6 +16,9 @@ export class Product extends BaseEntity {
     shop: string;
 
     @Column({ type: 'varchar', length: 255 })
+    shopUrl: string;
+
+    @Column({ type: 'varchar', length: 255 })
     imageUrl: string;
 
     @OneToMany(() => TrackingProduct, (trackingProduct) => trackingProduct.productId)

--- a/backend/src/entities/product.entity.ts
+++ b/backend/src/entities/product.entity.ts
@@ -1,1 +1,23 @@
-export class Product {}
+import { BaseEntity, Column, Entity, OneToMany, PrimaryColumn } from 'typeorm';
+import { TrackingProduct } from './trackingProduct.entity';
+
+@Entity()
+export class Product extends BaseEntity {
+    @PrimaryColumn({ type: 'char', length: 36 })
+    id: string;
+
+    @Column({ type: 'varchar', length: 255 })
+    productName: string;
+
+    @Column({ type: 'varchar', length: 16 })
+    productCode: string;
+
+    @Column({ type: 'varchar', length: 16 })
+    shop: string;
+
+    @Column({ type: 'varchar', length: 255 })
+    imageUrl: string;
+
+    @OneToMany(() => TrackingProduct, (trackingProduct) => trackingProduct.productId)
+    trackingProduct: TrackingProduct[];
+}

--- a/backend/src/entities/trackingProduct.entity.ts
+++ b/backend/src/entities/trackingProduct.entity.ts
@@ -1,0 +1,21 @@
+import { BaseEntity, Column, Entity, ManyToOne, PrimaryColumn } from 'typeorm';
+import { User } from './user.entity';
+import { Product } from './product.entity';
+
+@Entity()
+export class TrackingProduct extends BaseEntity {
+    @PrimaryColumn({ type: 'char', length: 36 })
+    userId: string;
+
+    @PrimaryColumn({ type: 'varchar', length: 36 })
+    productId: string;
+
+    @Column({ type: 'int' })
+    targetPrice: number;
+
+    @ManyToOne(() => User, (user) => user.id)
+    user: User;
+
+    @ManyToOne(() => Product, (product) => product.id)
+    product: Product;
+}

--- a/backend/src/entities/user.entity.ts
+++ b/backend/src/entities/user.entity.ts
@@ -1,5 +1,6 @@
-import { Entity, PrimaryGeneratedColumn, Column, BaseEntity, Unique } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, BaseEntity, Unique, OneToMany } from 'typeorm';
 import { IsNotEmpty } from 'class-validator';
+import { TrackingProduct } from './trackingProduct.entity';
 
 @Entity()
 @Unique(['email'])
@@ -18,4 +19,7 @@ export class User extends BaseEntity {
     @Column()
     @IsNotEmpty()
     password: string;
+
+    @OneToMany(() => TrackingProduct, (trackingProduct) => trackingProduct.userId)
+    trackingProduct: TrackingProduct[];
 }

--- a/backend/src/exceptions/http.exception.filter.ts
+++ b/backend/src/exceptions/http.exception.filter.ts
@@ -1,7 +1,7 @@
 import { ArgumentsHost, ExceptionFilter, HttpException } from '@nestjs/common';
 import { Response } from 'express';
 
-export class AuthExceptionFilter implements ExceptionFilter {
+export class HttpExceptionFilter implements ExceptionFilter {
     catch(exception: HttpException, host: ArgumentsHost) {
         const ctx = host.switchToHttp();
         const response = ctx.getResponse<Response>();

--- a/backend/src/product/product.controller.ts
+++ b/backend/src/product/product.controller.ts
@@ -1,4 +1,16 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, Req, UseGuards, HttpStatus } from '@nestjs/common';
+import {
+    Controller,
+    Get,
+    Post,
+    Body,
+    Patch,
+    Param,
+    Delete,
+    Req,
+    UseGuards,
+    HttpStatus,
+    UseFilters,
+} from '@nestjs/common';
 import { ProductService } from './product.service';
 import { ProductUrlDto } from '../dto/product.url.dto';
 import { ProductDto } from 'src/dto/product.dto';
@@ -27,6 +39,7 @@ import {
 } from 'src/dto/product.swagger.dto';
 import { User } from 'src/entities/user.entity';
 import { AuthGuard } from '@nestjs/passport';
+import { HttpExceptionFilter } from 'src/exceptions/http.exception.filter';
 
 @ApiBearerAuth()
 @ApiHeader({
@@ -36,6 +49,7 @@ import { AuthGuard } from '@nestjs/passport';
 @ApiTags('상품 API')
 @ApiUnauthorizedResponse({ type: UnauthorizedRequest, description: '승인되지 않은 요청' })
 @Controller('product')
+@UseFilters(HttpExceptionFilter)
 @UseGuards(AuthGuard('access'))
 export class ProductController {
     constructor(private readonly productService: ProductService) {}

--- a/backend/src/product/product.controller.ts
+++ b/backend/src/product/product.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, Req, UseGuards, HttpStatus } from '@nestjs/common';
 import { ProductService } from './product.service';
 import { ProductUrlDto } from '../dto/product.url.dto';
 import { ProductDto } from 'src/dto/product.dto';
@@ -25,6 +25,8 @@ import {
     UpdateTargetPriceSuccess,
     DeleteProductSuccess,
 } from 'src/dto/product.swagger.dto';
+import { User } from 'src/entities/user.entity';
+import { AuthGuard } from '@nestjs/passport';
 
 @ApiBearerAuth()
 @ApiHeader({
@@ -34,6 +36,7 @@ import {
 @ApiTags('상품 API')
 @ApiUnauthorizedResponse({ type: UnauthorizedRequest, description: '승인되지 않은 요청' })
 @Controller('product')
+@UseGuards(AuthGuard('access'))
 export class ProductController {
     constructor(private readonly productService: ProductService) {}
 
@@ -59,8 +62,9 @@ export class ProductController {
     @ApiOkResponse({ type: GetTrackingListSuccess, description: '상품 목록 조회 성공' })
     @ApiNotFoundResponse({ type: ProductNotFound, description: '추가한 상품이 없어서 상품 목록을 조회할 수 없습니다.' })
     @Get('/tracking')
-    getTrackingList() {
-        return this.productService.getTrackingList();
+    async getTrackingList(@Req() req: Request & { user: User }) {
+        const trackingList = await this.productService.getTrackingList(req.user.id);
+        return { statusCode: HttpStatus.OK, message: '상품 목록 조회 성공', trackingList: trackingList };
     }
 
     @ApiOperation({ summary: '추천 상품 목록 조회 API', description: '추천 상품 목록을 조회한다.' })

--- a/backend/src/product/product.controller.ts
+++ b/backend/src/product/product.controller.ts
@@ -76,7 +76,7 @@ export class ProductController {
     @ApiOkResponse({ type: GetTrackingListSuccess, description: '상품 목록 조회 성공' })
     @ApiNotFoundResponse({ type: ProductNotFound, description: '추가한 상품이 없어서 상품 목록을 조회할 수 없습니다.' })
     @Get('/tracking')
-    async getTrackingList(@Req() req: Request & { user: User }) {
+    async getTrackingList(@Req() req: Request & { user: User }): Promise<GetTrackingListSuccess> {
         const trackingList = await this.productService.getTrackingList(req.user.id);
         return { statusCode: HttpStatus.OK, message: '상품 목록 조회 성공', trackingList: trackingList };
     }

--- a/backend/src/product/product.controller.ts
+++ b/backend/src/product/product.controller.ts
@@ -48,7 +48,6 @@ import { HttpExceptionFilter } from 'src/exceptions/http.exception.filter';
 })
 @ApiTags('상품 API')
 @ApiUnauthorizedResponse({ type: UnauthorizedRequest, description: '승인되지 않은 요청' })
-@UseGuards(AuthGuard('access'))
 @Controller('product')
 @UseFilters(HttpExceptionFilter)
 @UseGuards(AuthGuard('access'))

--- a/backend/src/product/product.module.ts
+++ b/backend/src/product/product.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
 import { ProductService } from './product.service';
 import { ProductController } from './product.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TrackingProduct } from 'src/entities/trackingProduct.entity';
 
 @Module({
+    imports: [TypeOrmModule.forFeature([TrackingProduct])],
     controllers: [ProductController],
     providers: [ProductService],
 })

--- a/backend/src/product/product.service.ts
+++ b/backend/src/product/product.service.ts
@@ -51,15 +51,15 @@ export class ProductService {
         if (trackingProductList.length === 0) {
             throw new HttpException('상품 목록을 찾을 수 없습니다.', HttpStatus.NOT_FOUND);
         }
-        const trackingListInfo = trackingProductList.map((product) => {
-            const { productName, productCode, shop, shopUrl, imageUrl } = product.product;
+        const trackingListInfo = trackingProductList.map(({ product, targetPrice }) => {
+            const { productName, productCode, shop, shopUrl, imageUrl } = product;
             return {
                 productName,
                 productCode,
                 shop,
                 shopUrl,
                 imageUrl,
-                targetPrice: product.targetPrice,
+                targetPrice: targetPrice,
                 price: 1234, // 임시 더미 가격 데이터
             };
         });

--- a/backend/src/product/product.service.ts
+++ b/backend/src/product/product.service.ts
@@ -1,9 +1,10 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { ProductUrlDto } from '../dto/product.url.dto';
 import { ProductDto } from '../dto/product.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { TrackingProduct } from 'src/entities/trackingProduct.entity';
 import { Repository } from 'typeorm';
+import { TrackingProductDto } from 'src/dto/product.tracking.dto';
 
 @Injectable()
 export class ProductService {
@@ -19,12 +20,14 @@ export class ProductService {
         console.log(productDto);
     }
 
-    async getTrackingList(userId: string): Promise<object[]> {
+    async getTrackingList(userId: string): Promise<TrackingProductDto[]> {
         const trackingProductList = await this.trackingProductRepository.find({
             where: { userId: userId },
             relations: ['product'],
         });
-
+        if (trackingProductList.length === 0) {
+            throw new HttpException('상품 목록을 찾을 수 없습니다.', HttpStatus.NOT_FOUND);
+        }
         const trackingListInfo = trackingProductList.map((product) => {
             const { productName, productCode, shop, shopUrl, imageUrl } = product.product;
             return {

--- a/backend/src/product/product.service.ts
+++ b/backend/src/product/product.service.ts
@@ -1,9 +1,16 @@
 import { Injectable } from '@nestjs/common';
 import { ProductUrlDto } from '../dto/product.url.dto';
 import { ProductDto } from '../dto/product.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { TrackingProduct } from 'src/entities/trackingProduct.entity';
+import { Repository } from 'typeorm';
 
 @Injectable()
 export class ProductService {
+    constructor(
+        @InjectRepository(TrackingProduct)
+        private trackingProductRepository: Repository<TrackingProduct>,
+    ) {}
     verifyUrl(productUrlDto: ProductUrlDto) {
         console.log(productUrlDto);
     }
@@ -12,7 +19,27 @@ export class ProductService {
         console.log(productDto);
     }
 
-    getTrackingList() {}
+    async getTrackingList(userId: string): Promise<object[]> {
+        const trackingProductList = await this.trackingProductRepository.find({
+            where: { userId: userId },
+            relations: ['product'],
+        });
+
+        const trackingListInfo = trackingProductList.map((product) => {
+            const { productName, productCode, shop, shopUrl, imageUrl } = product.product;
+            return {
+                productName,
+                productCode,
+                shop,
+                shopUrl,
+                imageUrl,
+                targetPrice: product.targetPrice,
+                price: 1234, // 임시 더미 가격 데이터
+            };
+        });
+
+        return trackingListInfo;
+    }
 
     getRecommendList() {}
 


### PR DESCRIPTION
Resolves #51 

## 진행 내용
- [x] 요청 사용자의 추적 상품 전체 목록 응답
- [x] 추적 중인 상품이 없을 경우 없다고 응답
- [x] 로그인을 통해 인증된 사용자만 이용 가능

- 추적 상품 전체 목록 조회 요청이 오면, accessToken의 payload에 있는 userId를 통해 사용자가 추적하고 있는 상품에 대한 정보를 응답해준다.
- 상품 가격은 임시로 더미 데이터를 사용하였다.
- 기존 AuthExceptionFilter를 이름을 변경하여 재사용하였다.

## 스크린샷 (선택)
![추적상품목록조회](https://github.com/boostcampwm2023/and09-PriceGuard/assets/39684860/04bafd50-2bbd-49ab-9806-f230a00dfcca)

![추적상품목록없음](https://github.com/boostcampwm2023/and09-PriceGuard/assets/39684860/643cf546-eacc-44eb-ba3f-ce1943d9db55)
