### PR TITLE
상품 추가 API 구현

### DIFF
--- a/backend/src/dto/product.add.dto.ts
+++ b/backend/src/dto/product.add.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ProductAddDto {
+    @ApiProperty({
+        example: '5897533626',
+        description: '상품 코드',
+        required: true,
+    })
+    productCode: string;
+    @ApiProperty({
+        example: 36000,
+        description: '목표 가격',
+        required: true,
+    })
+    targetPrice: number;
+}

--- a/backend/src/dto/product.dto.ts
+++ b/backend/src/dto/product.dto.ts
@@ -1,16 +1,7 @@
-import { ApiProperty } from '@nestjs/swagger';
-
 export class ProductDto {
-    @ApiProperty({
-        example: '5897533626',
-        description: '상품 코드',
-        required: true,
-    })
+    productName: string;
     productCode: string;
-    @ApiProperty({
-        example: 36000,
-        description: '목표 가격',
-        required: true,
-    })
-    targetPrice: number;
+    shop: string;
+    shopUrl: string;
+    imageUrl: string;
 }

--- a/backend/src/dto/product.dto.ts
+++ b/backend/src/dto/product.dto.ts
@@ -8,9 +8,9 @@ export class ProductDto {
     })
     productCode: string;
     @ApiProperty({
-        example: '36000',
+        example: 36000,
         description: '목표 가격',
         required: true,
     })
-    targetPrice: string;
+    targetPrice: number;
 }

--- a/backend/src/dto/product.swagger.dto.ts
+++ b/backend/src/dto/product.swagger.dto.ts
@@ -91,6 +91,20 @@ export class RequestError {
     })
     message: string;
 }
+
+export class ProductCodeError {
+    @ApiProperty({
+        example: HttpStatus.BAD_REQUEST,
+        description: 'Http 상태 코드',
+    })
+    statusCode: number;
+    @ApiProperty({
+        example: '존재하지 않는 상품 코드입니다.',
+        description: '메시지',
+    })
+    message: string;
+}
+
 const productListExample = [
     {
         productName: 'Hallmark Keepsake 해리포터 마법의 분류 모자 크리스마스 장식',

--- a/backend/src/entities/product.entity.ts
+++ b/backend/src/entities/product.entity.ts
@@ -1,9 +1,9 @@
-import { BaseEntity, Column, Entity, OneToMany, PrimaryColumn } from 'typeorm';
+import { BaseEntity, Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 import { TrackingProduct } from './trackingProduct.entity';
 
 @Entity()
 export class Product extends BaseEntity {
-    @PrimaryColumn({ type: 'char', length: 36 })
+    @PrimaryGeneratedColumn('uuid')
     id: string;
 
     @Column({ type: 'varchar', length: 255 })

--- a/backend/src/product/product.controller.ts
+++ b/backend/src/product/product.controller.ts
@@ -78,8 +78,9 @@ export class ProductController {
     @ApiOkResponse({ type: VerifyUrlSuccess, description: '상품 추가 성공' })
     @ApiBadRequestResponse({ type: RequestError, description: '잘못된 요청' })
     @Post()
-    addProduct(@Body() productDto: ProductDto) {
-        return this.productService.addProduct(productDto);
+    async addProduct(@Req() req: Request & { user: User }, @Body() productDto: ProductDto) {
+        await this.productService.addProduct(req.user.id, productDto);
+        return { statusCode: HttpStatus.OK, message: '상품 추가 성공' };
     }
 
     @ApiOperation({ summary: '상품 목록 조회 API', description: '사용자가 추가한 상품 목록을 조회한다.' })

--- a/backend/src/product/product.controller.ts
+++ b/backend/src/product/product.controller.ts
@@ -36,6 +36,7 @@ import {
     GetRecommendListSuccess,
     UpdateTargetPriceSuccess,
     DeleteProductSuccess,
+    ProductCodeError,
 } from 'src/dto/product.swagger.dto';
 import { User } from 'src/entities/user.entity';
 import { AuthGuard } from '@nestjs/passport';
@@ -76,7 +77,7 @@ export class ProductController {
     @ApiOperation({ summary: '상품 추가 API', description: '상품을 추가한다' })
     @ApiBody({ type: ProductAddDto })
     @ApiOkResponse({ type: VerifyUrlSuccess, description: '상품 추가 성공' })
-    @ApiBadRequestResponse({ type: RequestError, description: '잘못된 요청' })
+    @ApiBadRequestResponse({ type: ProductCodeError, description: '상품 추가 실패' })
     @Post()
     async addProduct(@Req() req: Request & { user: User }, @Body() productAddDto: ProductAddDto) {
         await this.productService.addProduct(req.user.id, productAddDto);

--- a/backend/src/product/product.controller.ts
+++ b/backend/src/product/product.controller.ts
@@ -13,7 +13,7 @@ import {
 } from '@nestjs/common';
 import { ProductService } from './product.service';
 import { ProductUrlDto } from '../dto/product.url.dto';
-import { ProductDto } from 'src/dto/product.dto';
+import { ProductAddDto } from 'src/dto/product.add.dto';
 import {
     ApiBadRequestResponse,
     ApiBearerAuth,
@@ -74,12 +74,12 @@ export class ProductController {
     }
 
     @ApiOperation({ summary: '상품 추가 API', description: '상품을 추가한다' })
-    @ApiBody({ type: ProductDto })
+    @ApiBody({ type: ProductAddDto })
     @ApiOkResponse({ type: VerifyUrlSuccess, description: '상품 추가 성공' })
     @ApiBadRequestResponse({ type: RequestError, description: '잘못된 요청' })
     @Post()
-    async addProduct(@Req() req: Request & { user: User }, @Body() productDto: ProductDto) {
-        await this.productService.addProduct(req.user.id, productDto);
+    async addProduct(@Req() req: Request & { user: User }, @Body() productAddDto: ProductAddDto) {
+        await this.productService.addProduct(req.user.id, productAddDto);
         return { statusCode: HttpStatus.OK, message: '상품 추가 성공' };
     }
 
@@ -112,8 +112,8 @@ export class ProductController {
     @ApiOkResponse({ type: UpdateTargetPriceSuccess, description: '상품 목표 가격 수정 성공' })
     @ApiBadRequestResponse({ type: RequestError, description: '잘못된 요청' })
     @Patch('/targetPrice')
-    updateTargetPrice(@Body() productDto: ProductDto) {
-        return this.productService.updateTargetPrice(productDto);
+    updateTargetPrice(@Body() productAddDto: ProductAddDto) {
+        return this.productService.updateTargetPrice(productAddDto);
     }
     @ApiOperation({ summary: '상품 삭제 API', description: '상품을 삭제한다.' })
     @ApiOkResponse({ type: DeleteProductSuccess, description: '상품 삭제 성공' })

--- a/backend/src/product/product.module.ts
+++ b/backend/src/product/product.module.ts
@@ -3,10 +3,13 @@ import { ProductService } from './product.service';
 import { ProductController } from './product.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { TrackingProduct } from 'src/entities/trackingProduct.entity';
+import { Product } from 'src/entities/product.entity';
+import { ProductRepository } from './product.repository';
+import { TrackingProductRepository } from './trackingProduct.repository';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([TrackingProduct])],
+    imports: [TypeOrmModule.forFeature([TrackingProduct, Product])],
     controllers: [ProductController],
-    providers: [ProductService],
+    providers: [ProductService, ProductRepository, TrackingProductRepository],
 })
 export class ProductModule {}

--- a/backend/src/product/product.repository.ts
+++ b/backend/src/product/product.repository.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Product } from 'src/entities/product.entity';
+import { ProductDetailsDto } from '../dto/product.details.dto';
+import { createUrl11st } from 'src/utils/openapi.11st';
+
+@Injectable()
+export class ProductRepository extends Repository<Product> {
+    constructor(
+        @InjectRepository(Product)
+        private repository: Repository<Product>,
+    ) {
+        super(repository.target, repository.manager, repository.queryRunner);
+    }
+
+    async saveProduct(productDetailsDto: ProductDetailsDto): Promise<Product> {
+        const { productName, productCode, shop, imageUrl } = productDetailsDto;
+        const shopUrl = createUrl11st(productCode);
+        const newProduct = Product.create({ productName, productCode, shop, shopUrl, imageUrl });
+        await newProduct.save();
+        return newProduct;
+    }
+}

--- a/backend/src/product/product.repository.ts
+++ b/backend/src/product/product.repository.ts
@@ -2,8 +2,9 @@ import { Injectable } from '@nestjs/common';
 import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Product } from 'src/entities/product.entity';
-import { ProductDetailsDto } from '../dto/product.details.dto';
 import { createUrl11st } from 'src/utils/openapi.11st';
+import { ProductDto } from 'src/dto/product.dto';
+import { ProductDetailsDto } from 'src/dto/product.details.dto';
 
 @Injectable()
 export class ProductRepository extends Repository<Product> {
@@ -14,8 +15,8 @@ export class ProductRepository extends Repository<Product> {
         super(repository.target, repository.manager, repository.queryRunner);
     }
 
-    async saveProduct(productDetailsDto: ProductDetailsDto): Promise<Product> {
-        const { productName, productCode, shop, imageUrl } = productDetailsDto;
+    async saveProduct(productDto: ProductDto | ProductDetailsDto): Promise<Product> {
+        const { productName, productCode, shop, imageUrl } = productDto;
         const shopUrl = createUrl11st(productCode);
         const newProduct = Product.create({ productName, productCode, shop, shopUrl, imageUrl });
         await newProduct.save();

--- a/backend/src/product/product.service.ts
+++ b/backend/src/product/product.service.ts
@@ -40,9 +40,7 @@ export class ProductService {
         }
     }
 
-    addProduct(productDto: ProductDto) {
-        console.log(productDto);
-    }
+    async addProduct(userId: string, productDto: ProductDto) {}
 
     async getTrackingList(userId: string): Promise<TrackingProductDto[]> {
         const trackingProductList = await this.trackingProductRepository.find({

--- a/backend/src/product/product.service.ts
+++ b/backend/src/product/product.service.ts
@@ -37,7 +37,7 @@ export class ProductService {
             where: { productCode: productCode },
         });
         const productInfo = existProduct === null ? await getProductInfo11st(productCode) : existProduct;
-        const product = await this.productRepository.saveProduct(productInfo);
+        const product = existProduct === null ? await this.productRepository.saveProduct(productInfo) : existProduct;
         await this.trackingProductRepository.saveTrackingProduct(userId, product.id, targetPrice);
     }
 

--- a/backend/src/product/product.service.ts
+++ b/backend/src/product/product.service.ts
@@ -23,12 +23,8 @@ export class ProductService {
         if (matchList === null) {
             throw new HttpException('URL이 유효하지 않습니다.', HttpStatus.BAD_REQUEST);
         }
-        try {
-            const [, code] = matchList;
-            return await getProductInfo11st(code);
-        } catch (e) {
-            throw new HttpException('URL이 유효하지 않습니다.', HttpStatus.BAD_REQUEST);
-        }
+        const productCode = matchList[1];
+        return await getProductInfo11st(productCode);
     }
 
     async addProduct(userId: string, productAddDto: ProductAddDto) {

--- a/backend/src/product/product.service.ts
+++ b/backend/src/product/product.service.ts
@@ -6,8 +6,7 @@ import { TrackingProduct } from 'src/entities/trackingProduct.entity';
 import { Repository } from 'typeorm';
 import { TrackingProductDto } from 'src/dto/product.tracking.dto';
 import { ProductDetailsDto } from 'src/dto/product.details.dto';
-import axios from 'axios';
-import { productInfo11st, xmlConvert11st } from 'src/utils/openapi.11st';
+import { getProductInfo11st } from 'src/utils/openapi.11st';
 
 const REGEXP_11ST = /http[s]?:\/\/(?:www\.|m\.)?11st\.co\.kr\/products\/(?:ma\/|m\/)?([1-9]\d*)(?:\?.*)?(?:\/share)?/;
 @Injectable()
@@ -24,17 +23,7 @@ export class ProductService {
         }
         try {
             const [, code] = matchList;
-            const openApiUrl = productInfo11st(code);
-            const xml = await axios.get(openApiUrl, { responseType: 'arraybuffer' });
-            const productDetails = xmlConvert11st(xml.data);
-            const price = productDetails['ProductPrice']['Price']['text'].replace(/(원|,)/g, '');
-            return {
-                productCode: productDetails['ProductCode']['text'],
-                productName: productDetails['ProductName']['text'],
-                productPrice: parseInt(price),
-                shop: '11번가',
-                imageUrl: productDetails['BasicImage']['text'],
-            };
+            return await getProductInfo11st(code);
         } catch (e) {
             throw new HttpException('URL이 유효하지 않습니다.', HttpStatus.BAD_REQUEST);
         }

--- a/backend/src/product/trackingProduct.repository.ts
+++ b/backend/src/product/trackingProduct.repository.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
+import { TrackingProduct } from 'src/entities/trackingProduct.entity';
+
+@Injectable()
+export class TrackingProductRepository extends Repository<TrackingProduct> {
+    constructor(
+        @InjectRepository(TrackingProduct)
+        private repository: Repository<TrackingProduct>,
+    ) {
+        super(repository.target, repository.manager, repository.queryRunner);
+    }
+
+    async saveTrackingProduct(userId: string, productId: string, targetPrice: number): Promise<TrackingProduct> {
+        const newTrackingProduct = TrackingProduct.create({ userId, productId, targetPrice });
+        await newTrackingProduct.save();
+        return newTrackingProduct;
+    }
+}

--- a/backend/src/utils/openapi.11st.ts
+++ b/backend/src/utils/openapi.11st.ts
@@ -37,7 +37,7 @@ export async function getProductInfo11st(productCode: string) {
             imageUrl: productDetails['BasicImage']['text'],
         };
     } catch (e) {
-        throw new HttpException('URL이 유효하지 않습니다.', HttpStatus.BAD_REQUEST);
+        throw new HttpException('존재하지 않는 상품 코드입니다.', HttpStatus.BAD_REQUEST);
     }
 }
 

--- a/backend/src/utils/openapi.11st.ts
+++ b/backend/src/utils/openapi.11st.ts
@@ -20,3 +20,7 @@ export function productInfo11st(productCode: string) {
     shopUrl.searchParams.append('productCode', productCode);
     return shopUrl.toString();
 }
+
+export function createUrl11st(productCode: string) {
+    return `http://www.11st.co.kr/products/${productCode}/share`;
+}

--- a/backend/src/utils/openapi.11st.ts
+++ b/backend/src/utils/openapi.11st.ts
@@ -1,8 +1,9 @@
 import { BASE_URL_11ST, OPEN_API_KEY_11ST } from 'src/constants';
 import * as convert from 'xml-js';
 import * as iconv from 'iconv-lite';
+import axios from 'axios';
 
-export function xmlConvert11st(xml: Buffer) {
+function xmlConvert11st(xml: Buffer) {
     const xmlUtf8 = iconv.decode(xml, 'EUC-KR').toString();
     const {
         ProductInfoResponse: { Product },
@@ -14,11 +15,25 @@ export function xmlConvert11st(xml: Buffer) {
     return Product;
 }
 
-export function productInfo11st(productCode: string) {
+function productInfoUrl11st(productCode: string) {
     const shopUrl = new URL(BASE_URL_11ST);
     shopUrl.searchParams.append('key', OPEN_API_KEY_11ST);
     shopUrl.searchParams.append('productCode', productCode);
     return shopUrl.toString();
+}
+
+export async function getProductInfo11st(productCode: string) {
+    const openApiUrl = productInfoUrl11st(productCode);
+    const xml = await axios.get(openApiUrl, { responseType: 'arraybuffer' });
+    const productDetails = xmlConvert11st(xml.data);
+    const price = productDetails['ProductPrice']['LowestPrice']['text'].replace(/(원|,)/g, '');
+    return {
+        productCode: productDetails['ProductCode']['text'],
+        productName: productDetails['ProductName']['text'],
+        productPrice: parseInt(price),
+        shop: '11번가',
+        imageUrl: productDetails['BasicImage']['text'],
+    };
 }
 
 export function createUrl11st(productCode: string) {


### PR DESCRIPTION
Resolves #43 

## 진행 내용
**상품 추가 API 로직**

1. 상품 코드를 통해 상품테이블에 등록된 상품인지 DB에서 검색
2. 최초로 등록되는 상품이면 상품 테이블에 상품 추가
3. 이미 등록된 상품이면 상품 추가 X
4. 상품 추적 테이블에 사용자 ID, 상품 ID, 목표 가격을 저장

**변경 사항**
* `ProductDetailsDto`는 OpenAPI에서 상품 정보를 받아오기 위해 필요한 DTO인데, Product Table에 저장하기 위한 용도의 DTO도 필요하다고 생각해서 `ProductDto`를 별도로 만들어줬음.
* 따라서 기존에 있던 `ProductDto`는 `ProductAddDto`로 변경
* 11번가 Open API 호출 코드 함수로 분리
* 11번가 Open API에서 불러오는 가격 정보를 `Price`(원가)에서 `LowestPrice`(할인가)로 변경
* 기존에 사용하던 `Repository<TrackingProduct>`를 별도의 클래스 `TrackingProductRepository`로 분리