### PR TITLE
상품 API 내부 에러 핸들링 코드 작성

### DIFF
--- a/backend/src/dto/product.add.dto.ts
+++ b/backend/src/dto/product.add.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
 
 export class ProductAddDto {
     @ApiProperty({
@@ -6,11 +7,15 @@ export class ProductAddDto {
         description: '상품 코드',
         required: true,
     })
+    @IsString()
+    @IsNotEmpty()
     productCode: string;
     @ApiProperty({
         example: 36000,
         description: '목표 가격',
         required: true,
     })
+    @IsNumber()
+    @IsNotEmpty()
     targetPrice: number;
 }

--- a/backend/src/exceptions/exception.fillter.ts
+++ b/backend/src/exceptions/exception.fillter.ts
@@ -12,17 +12,17 @@ export class UserExceptionFilter implements ExceptionFilter {
         const response = ctx.getResponse<Response>();
         this.logger.error(exception.message);
         if (exception.message.includes('Duplicate entry')) {
-            this.setResposne(response, HttpStatus.CONFLICT, '이메일 중복');
+            this.setResponse(response, HttpStatus.CONFLICT, '이메일 중복');
             return;
         }
         if (exception instanceof ValidationException) {
-            this.setResposne(response, exception.getStatus(), exception.getMessage());
+            this.setResponse(response, exception.getStatus(), exception.getMessage());
             return;
         }
-        this.setResposne(response, HttpStatus.INTERNAL_SERVER_ERROR, '서버 내부 에러');
+        this.setResponse(response, HttpStatus.INTERNAL_SERVER_ERROR, '서버 내부 에러');
     }
 
-    private setResposne(response: Response, statusCode: number, msg: string) {
+    private setResponse(response: Response, statusCode: number, msg: string) {
         response.status(statusCode).json({
             statusCode: statusCode,
             message: msg,

--- a/backend/src/exceptions/validation.pipe.ts
+++ b/backend/src/exceptions/validation.pipe.ts
@@ -1,7 +1,7 @@
 import { ValidationPipe } from '@nestjs/common';
 import { ValidationException } from './validation.exception';
 
-export class UserValidationPipe extends ValidationPipe {
+export class GlobalValidationPipe extends ValidationPipe {
     exceptionFactory = (errors: any[]) => {
         errors.map((error) => {
             return {

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,10 +1,11 @@
 import { NestFactory } from '@nestjs/core';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
+import { GlobalValidationPipe } from './exceptions/validation.pipe';
 
 async function bootstrap() {
     const app = await NestFactory.create(AppModule);
-
+    app.useGlobalPipes(new GlobalValidationPipe());
     const config = new DocumentBuilder()
         .setTitle('PriceGuard')
         .setDescription('PriceGuard API 문서')

--- a/backend/src/product/product.service.ts
+++ b/backend/src/product/product.service.ts
@@ -18,41 +18,23 @@ export class ProductService {
         private productRepository: ProductRepository,
     ) {}
     async verifyUrl(productUrlDto: ProductUrlDto): Promise<ProductDetailsDto> {
-        try {
-            const { productUrl } = productUrlDto;
-            const matchList = productUrl.match(REGEXP_11ST);
-            if (matchList === null) {
-                throw new HttpException('URL이 유효하지 않습니다.', HttpStatus.BAD_REQUEST);
-            }
-            const productCode = matchList[1];
-            return await getProductInfo11st(productCode);
-        } catch (error) {
-            if (error.status) {
-                throw new HttpException(error.response, error.status);
-            }
-            throw new HttpException('서버 내부 에러', HttpStatus.INTERNAL_SERVER_ERROR);
+        const { productUrl } = productUrlDto;
+        const matchList = productUrl.match(REGEXP_11ST);
+        if (matchList === null) {
+            throw new HttpException('URL이 유효하지 않습니다.', HttpStatus.BAD_REQUEST);
         }
+        const productCode = matchList[1];
+        return await getProductInfo11st(productCode);
     }
 
     async addProduct(userId: string, productAddDto: ProductAddDto) {
-        try {
-            const { productCode, targetPrice } = productAddDto;
-            const existProduct = await this.productRepository.findOne({
-                where: { productCode: productCode },
-            });
-            const productInfo = existProduct === null ? await getProductInfo11st(productCode) : existProduct;
-            const product =
-                existProduct === null ? await this.productRepository.saveProduct(productInfo) : existProduct;
-            await this.trackingProductRepository.saveTrackingProduct(userId, product.id, targetPrice);
-        } catch (error) {
-            if (error.status) {
-                throw new HttpException(error.response, error.status);
-            }
-            if (error.code === 'ER_NO_DEFAULT_FOR_FIELD' || error.code === 'ER_TRUNCATED_WRONG_VALUE_FOR_FIELD') {
-                throw new HttpException('입력 값이 유효하지 않습니다', HttpStatus.BAD_REQUEST);
-            }
-            throw new HttpException('서버 내부 에러', HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+        const { productCode, targetPrice } = productAddDto;
+        const existProduct = await this.productRepository.findOne({
+            where: { productCode: productCode },
+        });
+        const productInfo = existProduct === null ? await getProductInfo11st(productCode) : existProduct;
+        const product = existProduct === null ? await this.productRepository.saveProduct(productInfo) : existProduct;
+        await this.trackingProductRepository.saveTrackingProduct(userId, product.id, targetPrice);
     }
 
     async getTrackingList(userId: string): Promise<TrackingProductDto[]> {

--- a/backend/src/product/product.service.ts
+++ b/backend/src/product/product.service.ts
@@ -18,23 +18,41 @@ export class ProductService {
         private productRepository: ProductRepository,
     ) {}
     async verifyUrl(productUrlDto: ProductUrlDto): Promise<ProductDetailsDto> {
-        const { productUrl } = productUrlDto;
-        const matchList = productUrl.match(REGEXP_11ST);
-        if (matchList === null) {
-            throw new HttpException('URL이 유효하지 않습니다.', HttpStatus.BAD_REQUEST);
+        try {
+            const { productUrl } = productUrlDto;
+            const matchList = productUrl.match(REGEXP_11ST);
+            if (matchList === null) {
+                throw new HttpException('URL이 유효하지 않습니다.', HttpStatus.BAD_REQUEST);
+            }
+            const productCode = matchList[1];
+            return await getProductInfo11st(productCode);
+        } catch (error) {
+            if (error.status) {
+                throw new HttpException(error.response, error.status);
+            }
+            throw new HttpException('서버 내부 에러', HttpStatus.INTERNAL_SERVER_ERROR);
         }
-        const productCode = matchList[1];
-        return await getProductInfo11st(productCode);
     }
 
     async addProduct(userId: string, productAddDto: ProductAddDto) {
-        const { productCode, targetPrice } = productAddDto;
-        const existProduct = await this.productRepository.findOne({
-            where: { productCode: productCode },
-        });
-        const productInfo = existProduct === null ? await getProductInfo11st(productCode) : existProduct;
-        const product = existProduct === null ? await this.productRepository.saveProduct(productInfo) : existProduct;
-        await this.trackingProductRepository.saveTrackingProduct(userId, product.id, targetPrice);
+        try {
+            const { productCode, targetPrice } = productAddDto;
+            const existProduct = await this.productRepository.findOne({
+                where: { productCode: productCode },
+            });
+            const productInfo = existProduct === null ? await getProductInfo11st(productCode) : existProduct;
+            const product =
+                existProduct === null ? await this.productRepository.saveProduct(productInfo) : existProduct;
+            await this.trackingProductRepository.saveTrackingProduct(userId, product.id, targetPrice);
+        } catch (error) {
+            if (error.status) {
+                throw new HttpException(error.response, error.status);
+            }
+            if (error.code === 'ER_NO_DEFAULT_FOR_FIELD' || error.code === 'ER_TRUNCATED_WRONG_VALUE_FOR_FIELD') {
+                throw new HttpException('입력 값이 유효하지 않습니다', HttpStatus.BAD_REQUEST);
+            }
+            throw new HttpException('서버 내부 에러', HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     async getTrackingList(userId: string): Promise<TrackingProductDto[]> {

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -1,8 +1,7 @@
-import { Body, Controller, Post, HttpStatus, UseFilters, UsePipes, forwardRef, Inject } from '@nestjs/common';
+import { Body, Controller, Post, HttpStatus, UseFilters, forwardRef, Inject } from '@nestjs/common';
 import { UsersService } from './user.service';
 import { UserDto } from '../dto/user.dto';
 import { UserExceptionFilter } from 'src/exceptions/exception.fillter';
-import { UserValidationPipe } from 'src/exceptions/validation.user.pipe';
 import { AuthService } from '../auth/auth.service';
 import { LoginDto } from '../dto/login.dto';
 import {
@@ -37,7 +36,6 @@ export class UsersController {
     @ApiBadRequestResponse({ type: BadRequestError, description: '유효하지 않은 입력 값' })
     @ApiConflictResponse({ type: DupEmailError, description: '이메일 중복' })
     @Post('register')
-    @UsePipes(new UserValidationPipe())
     async registerUser(@Body() userDto: UserDto): Promise<RegisterSuccess> {
         const user = await this.userService.registerUser(userDto);
         const accessToken = await this.authService.getAccessToken(user);
@@ -50,7 +48,6 @@ export class UsersController {
     @ApiOkResponse({ type: LoginSuccess, description: '로그인 성공' })
     @ApiBadRequestResponse({ type: LoginFailError, description: '로그인 실패' })
     @Post('login')
-    @UsePipes(new UserValidationPipe())
     async loginUser(@Body() loginDto: LoginDto): Promise<LoginSuccess> {
         const { email, password } = loginDto;
         const { accessToken, refreshToken } = await this.authService.validateUser(email, password);


### PR DESCRIPTION
### 현재 이슈
* 상품 추가 API, 상품 링크 검증 API에 유효하지 않은 값들이 들어올 때, 에러 발생
* 상품 API에서는 `HttpExceptionFilter`가 에러를 관리,
* `HttpExceptionFilter`에서 에러에 대한 response(400, 401, 404, 500 등)를 클라이언트에게 전달

**그러나 HttpException 타입이 아닌 에러는 HttpExceptionFilter에서 에러 발생**
`ex) error.getStatus() is not function`

### 해결 과정
* dto에 IsString, IsNumber, IsNotEmpty등과 같은 데코레이터 추가
* ~~try-catch문으로 타입이 맞지 않거나 빈 값일 경우`(ER_NO_DEFAULT_FOR_FIELD, ER_TRUNCATED_WRONG_VALUE_FOR_FIELD)`에 HttpException 생성~~
* 기존에 UserDTO 유효성 검사를 위해 사용하던 `UserValidationPipe`를 `GlobalValidationPipe`로 사용
* 모든 API 요청에 대해 유효성 검사를 하고 예외 처리를 할 수 있음.
* 최종적으로 `HttpExceptionFilter`에서 response를 정상적으로 전달

