### PR TITLE
상품 세부 정보 조회 API 구현

### DIFF
--- a/backend/src/dto/product.details.dto.ts
+++ b/backend/src/dto/product.details.dto.ts
@@ -1,7 +1,9 @@
 export class ProductDetailsDto {
     productName: string;
-    productCode: string;
-    productPrice: number;
     shop: string;
     imageUrl: string;
+    rank: string;
+    shopUrl: string;
+    targetPrice: number;
+    price: number;
 }

--- a/backend/src/dto/product.info.dto.ts
+++ b/backend/src/dto/product.info.dto.ts
@@ -1,0 +1,7 @@
+export class ProductInfoDto {
+    productName: string;
+    productCode: string;
+    productPrice: number;
+    shop: string;
+    imageUrl: string;
+}

--- a/backend/src/dto/product.swagger.dto.ts
+++ b/backend/src/dto/product.swagger.dto.ts
@@ -1,6 +1,6 @@
 import { HttpStatus } from '@nestjs/common';
 import { ApiProperty } from '@nestjs/swagger';
-import { ProductDetailsDto } from './product.details.dto';
+import { ProductInfoDto } from './product.info.dto';
 import { TrackingProductDto } from './product.tracking.dto';
 
 export class VerifyUrlSuccess {
@@ -187,9 +187,60 @@ export class GetRecommendListSuccess {
         example: JSON.stringify(productListExample, null, 2),
         description: '추천 상품 목록',
     })
-    recommendList: ProductDetailsDto[];
+    recommendList: ProductInfoDto[];
 }
-
+export class ProductDetailsSuccess {
+    @ApiProperty({
+        example: HttpStatus.OK,
+        description: 'Http 상태 코드',
+    })
+    statusCode: number;
+    @ApiProperty({
+        example: '상품 상세 정보 조회 성공',
+        description: '메시지',
+    })
+    message: string;
+    @ApiProperty({
+        example: 'Hallmark Keepsake 해리포터 마법의 분류 모자 크리스마스 장식',
+        description: '상품명',
+    })
+    productName: string;
+    @ApiProperty({
+        example: '5897533626',
+        description: '상품 코드',
+    })
+    productCode: string;
+    @ApiProperty({
+        example: '11번가',
+        description: '쇼핑몰 이름',
+    })
+    shop: string;
+    @ApiProperty({
+        example: 'https://cdn.011st.com/11dims/strip/false/11src/asin/B091516D2Z/B.jpg?1700527038699',
+        description: '상품 이미지 URL',
+    })
+    imageUrl: string;
+    @ApiProperty({
+        example: '1',
+        description: '상품 순위',
+    })
+    rank: string;
+    @ApiProperty({
+        example: 'http://www.11st.co.kr/products/5897533626/share',
+        description: '상품 링크',
+    })
+    shopUrl: string;
+    @ApiProperty({
+        example: '50000',
+        description: '사용자 목표 가격',
+    })
+    targetPrice: number;
+    @ApiProperty({
+        example: '53730',
+        description: '상품 현재 가격',
+    })
+    price: number;
+}
 export class ProductNotFound {
     @ApiProperty({
         example: HttpStatus.NOT_FOUND,

--- a/backend/src/product/product.controller.ts
+++ b/backend/src/product/product.controller.ts
@@ -116,7 +116,7 @@ export class ProductController {
     @Get(':productCode')
     async getProductDetails(@Req() req: Request & { user: User }, @Param('productCode') productCode: string) {
         const { productName, shop, imageUrl, rank, shopUrl, targetPrice, price } =
-            await this.productService.getProductDetails(productCode);
+            await this.productService.getProductDetails(req.user.id, productCode);
         return {
             statusCode: HttpStatus.OK,
             message: '상품 URL 검증 성공',

--- a/backend/src/product/product.controller.ts
+++ b/backend/src/product/product.controller.ts
@@ -40,6 +40,7 @@ import {
     ProductCodeError,
     TrackingProductsNotFound,
     AddProductConflict,
+    ProductDetailsSuccess,
 } from 'src/dto/product.swagger.dto';
 import { User } from 'src/entities/user.entity';
 import { AuthGuard } from '@nestjs/passport';
@@ -109,12 +110,25 @@ export class ProductController {
     }
 
     @ApiOperation({ summary: '상품 세부 정보 조회 API', description: '상품 세부 정보를 조회한다.' })
-    @ApiOkResponse({ type: VerifyUrlSuccess, description: '상품 세부 정보 조회 성공' })
+    @ApiOkResponse({ type: ProductDetailsSuccess, description: '상품 세부 정보 조회 성공' })
     @ApiNotFoundResponse({ type: ProductDetailsNotFound, description: '상품 정보가 존재하지 않습니다.' })
     @ApiBadRequestResponse({ type: RequestError, description: '잘못된 요청입니다.' })
     @Get(':productCode')
-    getProductDetails(@Param('productCode') productCode: string) {
-        return this.productService.getProductDetails(productCode);
+    async getProductDetails(@Req() req: Request & { user: User }, @Param('productCode') productCode: string) {
+        const { productName, shop, imageUrl, rank, shopUrl, targetPrice, price } =
+            await this.productService.getProductDetails(productCode);
+        return {
+            statusCode: HttpStatus.OK,
+            message: '상품 URL 검증 성공',
+            productName,
+            productCode,
+            shop,
+            imageUrl,
+            rank,
+            shopUrl,
+            targetPrice,
+            price,
+        };
     }
 
     @ApiOperation({ summary: '상품 목표 가격 수정 API', description: '상품 목표 가격을 수정한다.' })

--- a/backend/src/product/product.repository.ts
+++ b/backend/src/product/product.repository.ts
@@ -4,7 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Product } from 'src/entities/product.entity';
 import { createUrl11st } from 'src/utils/openapi.11st';
 import { ProductDto } from 'src/dto/product.dto';
-import { ProductDetailsDto } from 'src/dto/product.details.dto';
+import { ProductInfoDto } from 'src/dto/product.info.dto';
 
 @Injectable()
 export class ProductRepository extends Repository<Product> {
@@ -15,7 +15,7 @@ export class ProductRepository extends Repository<Product> {
         super(repository.target, repository.manager, repository.queryRunner);
     }
 
-    async saveProduct(productDto: ProductDto | ProductDetailsDto): Promise<Product> {
+    async saveProduct(productDto: ProductDto | ProductInfoDto): Promise<Product> {
         const { productName, productCode, shop, imageUrl } = productDto;
         const shopUrl = createUrl11st(productCode);
         const newProduct = Product.create({ productName, productCode, shop, shopUrl, imageUrl });

--- a/backend/src/product/product.service.ts
+++ b/backend/src/product/product.service.ts
@@ -70,7 +70,27 @@ export class ProductService {
 
     getRecommendList() {}
 
-    async getProductDetails(userId: string, productCode: string): Promise<ProductDetailsDto> {}
+    async getProductDetails(userId: string, productCode: string): Promise<ProductDetailsDto> {
+        const selectProduct = await this.productRepository.findOne({
+            where: { productCode: productCode },
+        });
+        if (selectProduct === null) {
+            throw new HttpException('상품 정보가 존재하지 않습니다.', HttpStatus.NOT_FOUND);
+        }
+        const isTracking = await this.trackingProductRepository.findOne({
+            where: { userId: userId, productId: selectProduct.id },
+        });
+
+        return {
+            productName: selectProduct.productName,
+            shop: selectProduct.shop,
+            imageUrl: selectProduct.imageUrl,
+            rank: '1',
+            shopUrl: selectProduct.shopUrl,
+            targetPrice: isTracking === null ? -1 : isTracking.targetPrice,
+            price: 777,
+        };
+    }
 
     async updateTargetPrice(userId: string, productAddDto: ProductAddDto) {
         const product = await this.findTrackingProductByCode(userId, productAddDto.productCode);

--- a/backend/src/product/product.service.ts
+++ b/backend/src/product/product.service.ts
@@ -3,10 +3,11 @@ import { ProductUrlDto } from '../dto/product.url.dto';
 import { ProductAddDto } from '../dto/product.add.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { TrackingProductDto } from 'src/dto/product.tracking.dto';
-import { ProductDetailsDto } from 'src/dto/product.details.dto';
+import { ProductInfoDto } from 'src/dto/product.info.dto';
 import { TrackingProductRepository } from './trackingProduct.repository';
 import { ProductRepository } from './product.repository';
 import { getProductInfo11st } from 'src/utils/openapi.11st';
+import { ProductDetailsDto } from 'src/dto/product.details.dto';
 
 const REGEXP_11ST = /http[s]?:\/\/(?:www\.|m\.)?11st\.co\.kr\/products\/(?:ma\/|m\/)?([1-9]\d*)(?:\?.*)?(?:\/share)?/;
 @Injectable()
@@ -17,7 +18,7 @@ export class ProductService {
         @InjectRepository(ProductRepository)
         private productRepository: ProductRepository,
     ) {}
-    async verifyUrl(productUrlDto: ProductUrlDto): Promise<ProductDetailsDto> {
+    async verifyUrl(productUrlDto: ProductUrlDto): Promise<ProductInfoDto> {
         const { productUrl } = productUrlDto;
         const matchList = productUrl.match(REGEXP_11ST);
         if (matchList === null) {
@@ -69,9 +70,7 @@ export class ProductService {
 
     getRecommendList() {}
 
-    getProductDetails(productCode: string) {
-        console.log(productCode);
-    }
+    async getProductDetails(userId: string, productCode: string): Promise<ProductDetailsDto> {}
 
     async updateTargetPrice(userId: string, productAddDto: ProductAddDto) {
         const product = await this.findTrackingProductByCode(userId, productAddDto.productCode);


### PR DESCRIPTION
## 진행 내용
* 상품 코드를 파라미터로 전달받아서 해당하는 상품에 대한 정보를 불러온다. 
* AccessToken에 있는 사용자의 id를 이용하여 상품 추적 테이블에 접근, 사용자의 목표 가격에 대한 정보를 가져온다. 
* 이 때, 사용자가 추적하지 않는 상품이라면 targetPrice 값으로 -1을 보내도록 구현.
* 상품의 현재 가격은 상품 최신 가격을 갱신해주는 로직이 필요하기 때문에, 더미 데이터를 넣었다.
* 또한 상품의 순위를 계산해주지 않고 일단 더미 데이터로 대체해서 보냈다.
