### PR TITLE
인기 상품 목록 API 구현

### DIFF
--- a/backend/src/dto/product.details.dto.ts
+++ b/backend/src/dto/product.details.dto.ts
@@ -2,7 +2,7 @@ export class ProductDetailsDto {
     productName: string;
     shop: string;
     imageUrl: string;
-    rank: string;
+    rank: number;
     shopUrl: string;
     targetPrice: number;
     lowestPrice: number;

--- a/backend/src/dto/product.swagger.dto.ts
+++ b/backend/src/dto/product.swagger.dto.ts
@@ -249,10 +249,10 @@ export class ProductDetailsSuccess {
     })
     imageUrl: string;
     @ApiProperty({
-        example: '1',
+        example: 1,
         description: '상품 순위',
     })
-    rank: string;
+    rank: number;
     @ApiProperty({
         example: 'http://www.11st.co.kr/products/5897533626/share',
         description: '상품 링크',

--- a/backend/src/dto/product.swagger.dto.ts
+++ b/backend/src/dto/product.swagger.dto.ts
@@ -118,21 +118,6 @@ export class ProductCodeError {
     message: string;
 }
 
-const productListExample = [
-    {
-        productName: 'Hallmark Keepsake 해리포터 마법의 분류 모자 크리스마스 장식',
-        productCode: '5897533626',
-        shop: '11번가',
-        imageUrl: 'https://cdn.011st.com/11dims/strip/false/11src/asin/B091516D2Z/B.jpg?1700527038699',
-    },
-    {
-        productName: 'Mercer Culinary 밀레니아 10인치 브레드 나이프 빵 칼 (M23210WBH)',
-        productCode: '3534429539',
-        shop: '11번가',
-        imageUrl: 'https://cdn.011st.com/11dims/strip/false/11src/asin/B01HZ0YT2C/B.jpg?1700390686058',
-    },
-];
-
 const trackingProductListExample = [
     {
         productName: 'Hallmark Keepsake 해리포터 마법의 분류 모자 크리스마스 장식',
@@ -172,6 +157,49 @@ export class GetTrackingListSuccess {
     trackingList: TrackingProductDto[];
 }
 
+const recommendProductListExample = [
+    {
+        statusCode: 200,
+        message: '추천 상품 목록 조회 성공',
+        recommendList: [
+            {
+                productName: '갤럭시 GALAX 지포스 RTX 4060 1X D6 8GB',
+                productCode: '6221602897',
+                shop: '11번가',
+                imageUrl: 'https://cdn.011st.com/11dims/strip/false/11src/product/6221602897/B.jpg?556000000',
+                price: 1234,
+                rank: 1,
+            },
+            {
+                productName: '본사) 쿠쿠 화이트 3구 인덕션레인지 CIR-E301FW',
+                productCode: '3969500068',
+                shop: '11번가',
+                imageUrl:
+                    'https://cdn.011st.com/11dims/strip/false/11src/dl/v2/5/0/0/0/6/8/pNOcE/3969500068_154126549.jpg',
+                price: 1234,
+                rank: 2,
+            },
+            {
+                productName:
+                    '[카드추가할인] 삼성전자 SL-T1670FW 잉크젯 플러스S 정품 무한 복합기 프린터 복사 팩스 스캔 WiFi 무선 지원 잉크포함',
+                productCode: '4725944460',
+                shop: '11번가',
+                imageUrl: 'https://cdn.011st.com/11dims/strip/false/11src/product/4725944460/B.jpg?338000000',
+                price: 1234,
+                rank: 3,
+            },
+            {
+                productName: 'Hallmark Keepsake 해리포터 마법의 분류 모자 크리스마스 장식',
+                productCode: '5897533626',
+                shop: '11번가',
+                imageUrl: 'https://cdn.011st.com/11dims/strip/false/11src/asin/B091516D2Z/B.jpg?1700715151392',
+                price: 1234,
+                rank: 4,
+            },
+        ],
+    },
+];
+
 export class GetRecommendListSuccess {
     @ApiProperty({
         example: HttpStatus.OK,
@@ -184,7 +212,7 @@ export class GetRecommendListSuccess {
     })
     message: string;
     @ApiProperty({
-        example: JSON.stringify(productListExample, null, 2),
+        example: JSON.stringify(recommendProductListExample, null, 2),
         description: '추천 상품 목록',
     })
     recommendList: ProductDetailsDto[];

--- a/backend/src/entities/trackingProduct.entity.ts
+++ b/backend/src/entities/trackingProduct.entity.ts
@@ -2,7 +2,7 @@ import { BaseEntity, Column, Entity, ManyToOne, PrimaryColumn } from 'typeorm';
 import { User } from './user.entity';
 import { Product } from './product.entity';
 
-@Entity()
+@Entity('tracking_product')
 export class TrackingProduct extends BaseEntity {
     @PrimaryColumn({ type: 'char', length: 36 })
     userId: string;

--- a/backend/src/product/product.controller.ts
+++ b/backend/src/product/product.controller.ts
@@ -104,8 +104,9 @@ export class ProductController {
     @ApiNotFoundResponse({ type: ProductNotFound, description: '추천 상품 목록이 없습니다.' })
     @ApiBadRequestResponse({ type: RequestError, description: '잘못된 요청입니다.' })
     @Get('/recommend')
-    getRecommendList() {
-        return this.productService.getRecommendList();
+    async getRecommendList() {
+        const recommendList = await this.productService.getRecommendList();
+        return { statusCode: HttpStatus.OK, message: '추천 상품 목록 조회 성공', recommendList: recommendList };
     }
 
     @ApiOperation({ summary: '상품 세부 정보 조회 API', description: '상품 세부 정보를 조회한다.' })

--- a/backend/src/product/product.controller.ts
+++ b/backend/src/product/product.controller.ts
@@ -116,7 +116,7 @@ export class ProductController {
     @ApiBadRequestResponse({ type: RequestError, description: '잘못된 요청입니다.' })
     @Get(':productCode')
     async getProductDetails(@Req() req: Request & { user: User }, @Param('productCode') productCode: string) {
-        const { productName, shop, imageUrl, rank, shopUrl, targetPrice, price } =
+        const { productName, shop, imageUrl, rank, shopUrl, targetPrice, lowestPrice, price } =
             await this.productService.getProductDetails(req.user.id, productCode);
         return {
             statusCode: HttpStatus.OK,
@@ -128,6 +128,7 @@ export class ProductController {
             rank,
             shopUrl,
             targetPrice,
+            lowestPrice,
             price,
         };
     }

--- a/backend/src/product/product.service.ts
+++ b/backend/src/product/product.service.ts
@@ -67,7 +67,21 @@ export class ProductService {
         return trackingListInfo;
     }
 
-    getRecommendList() {}
+    async getRecommendList() {
+        const recommendList = await this.trackingProductRepository.getRankigList();
+        const recommendListInfo = recommendList.map((product, index) => {
+            const { productName, productCode, shop, imageUrl } = product;
+            return {
+                productName,
+                productCode,
+                shop,
+                imageUrl,
+                price: 1234, // 임시 더미 가격 데이터
+                rank: index + 1,
+            };
+        });
+        return recommendListInfo;
+    }
 
     getProductDetails(productCode: string) {
         console.log(productCode);

--- a/backend/src/product/product.service.ts
+++ b/backend/src/product/product.service.ts
@@ -69,7 +69,7 @@ export class ProductService {
     }
 
     async getRecommendList() {
-        const recommendList = await this.trackingProductRepository.getRankigList();
+        const recommendList = await this.trackingProductRepository.getRankingList();
         const recommendListInfo = recommendList.map((product, index) => {
             const { productName, productCode, shop, imageUrl } = product;
             return {
@@ -99,7 +99,7 @@ export class ProductService {
             productName: selectProduct.productName,
             shop: selectProduct.shop,
             imageUrl: selectProduct.imageUrl,
-            rank: '1',
+            rank: 1,
             shopUrl: selectProduct.shopUrl,
             targetPrice: trackingProduct ? trackingProduct.targetPrice : -1,
             lowestPrice: 500,

--- a/backend/src/product/trackingProduct.repository.ts
+++ b/backend/src/product/trackingProduct.repository.ts
@@ -19,7 +19,7 @@ export class TrackingProductRepository extends Repository<TrackingProduct> {
         return newTrackingProduct;
     }
 
-    async getRankigList() {
+    async getRankingList() {
         const recommendList = await this.repository
             .createQueryBuilder('tracking_product')
             .select([

--- a/backend/src/product/trackingProduct.repository.ts
+++ b/backend/src/product/trackingProduct.repository.ts
@@ -17,4 +17,14 @@ export class TrackingProductRepository extends Repository<TrackingProduct> {
         await newTrackingProduct.save();
         return newTrackingProduct;
     }
+
+    async getRankigList() {
+        const recommendList = await this.repository
+            .createQueryBuilder('tracking_product')
+            .select('tracking_product.productId as productId')
+            .groupBy('tracking_product.productId')
+            .orderBy('COUNT(tracking_product.userId)', 'DESC')
+            .getRawMany();
+        return recommendList;
+    }
 }

--- a/backend/src/product/trackingProduct.repository.ts
+++ b/backend/src/product/trackingProduct.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { TrackingProduct } from 'src/entities/trackingProduct.entity';
+import { Product } from 'src/entities/product.entity';
 
 @Injectable()
 export class TrackingProductRepository extends Repository<TrackingProduct> {
@@ -21,9 +22,17 @@ export class TrackingProductRepository extends Repository<TrackingProduct> {
     async getRankigList() {
         const recommendList = await this.repository
             .createQueryBuilder('tracking_product')
-            .select('tracking_product.productId as productId')
+            .select([
+                'tracking_product.productId as productId',
+                'COUNT(tracking_product.userId) as userCount',
+                'product.productName as productName',
+                'product.productCode as productCode',
+                'product.shop as shop',
+                'product.imageUrl as imageUrl',
+            ])
+            .leftJoin(Product, 'product', 'tracking_product.productId = product.id')
             .groupBy('tracking_product.productId')
-            .orderBy('COUNT(tracking_product.userId)', 'DESC')
+            .orderBy('userCount', 'DESC')
             .getRawMany();
         return recommendList;
     }


### PR DESCRIPTION
Resolves #3 

## 진행 내용
- [x] 모든 추적 상품에 대하여 추적 중인 사용자가 많은 순서로 인기 상품 목록을 응답하는 API 구현

상품 추적 테이블과 상품 테이블을 left join하고 productId를 기준으로 그룹화 한 후,
사용자Id를 카운트 한 것을 기준으로 정렬하였다.
가격 정보는 더미 값을 사용하였다.
