### PR TITLE
상품 인기 순위 섞이는 버그 수정

### DIFF
--- a/backend/src/product/trackingProduct.repository.ts
+++ b/backend/src/product/trackingProduct.repository.ts
@@ -34,6 +34,7 @@ export class TrackingProductRepository extends Repository<TrackingProduct> {
             .leftJoin(Product, 'product', 'tracking_product.productId = product.id')
             .groupBy('tracking_product.productId')
             .orderBy('userCount', 'DESC')
+            .addOrderBy('MAX(tracking_product.productId)', 'DESC')
             .take(MAX_TRACKING_RANK)
             .getRawMany();
         return recommendList;
@@ -45,6 +46,7 @@ export class TrackingProductRepository extends Repository<TrackingProduct> {
             .select('tracking_product.productId as productId')
             .groupBy('tracking_product.productId')
             .orderBy('COUNT(tracking_product.userId)', 'DESC')
+            .addOrderBy('MAX(tracking_product.productId)', 'DESC')
             .take(MAX_TRACKING_RANK)
             .getRawMany();
         return rankList;


### PR DESCRIPTION
## 진행 내용
- [x] 상품을 추적 중인 유저 수가 같을 때, 상세 정보와 인기 화면에서 보이는 순위가 다른 버그 수정
- 순위 정렬 기준 추가 하여 버그 수정
