### PR TITLE
logger 미들웨어 추가

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { TypeOrmConfig } from './configs/typeorm.config';
 import { UsersModule } from './user/user.module';
@@ -8,6 +8,7 @@ import { winstonConfig } from './configs/winston.config';
 import { ProductModule } from './product/product.module';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { LoggerMiddleware } from './middlewares/logger.middleware';
 
 @Module({
     imports: [
@@ -20,4 +21,8 @@ import { AppService } from './app.service';
     controllers: [AppController],
     providers: [AppService],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+    configure(consumer: MiddlewareConsumer) {
+        consumer.apply(LoggerMiddleware).exclude('/app').forRoutes('*');
+    }
+}

--- a/backend/src/exceptions/http.exception.filter.ts
+++ b/backend/src/exceptions/http.exception.filter.ts
@@ -1,10 +1,11 @@
-import { ArgumentsHost, ExceptionFilter, HttpException, Inject } from '@nestjs/common';
+import { ArgumentsHost, Catch, ExceptionFilter, HttpException, Inject } from '@nestjs/common';
 import { Response } from 'express';
-import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
 
+@Catch(HttpException)
 export class HttpExceptionFilter implements ExceptionFilter {
-    constructor(@Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: Logger) {}
+    constructor(@Inject(WINSTON_MODULE_PROVIDER) private readonly logger: Logger) {}
     catch(exception: HttpException, host: ArgumentsHost) {
         const ctx = host.switchToHttp();
         const response = ctx.getResponse<Response>();

--- a/backend/src/middlewares/logger.middleware.ts
+++ b/backend/src/middlewares/logger.middleware.ts
@@ -1,0 +1,17 @@
+import { Inject, Injectable, NestMiddleware } from '@nestjs/common';
+import { NextFunction, Request, Response } from 'express';
+import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
+import { Logger } from 'winston';
+
+@Injectable()
+export class LoggerMiddleware implements NestMiddleware {
+    constructor(@Inject(WINSTON_MODULE_PROVIDER) private readonly logger: Logger) {}
+    use(request: Request, response: Response, next: NextFunction) {
+        const { ip, method, originalUrl } = request;
+        const userAgent = request.get('user-agent');
+        request.on('close', () => {
+            this.logger.info(`${method} ${originalUrl} - ${userAgent} ${ip}`);
+        });
+        next();
+    }
+}


### PR DESCRIPTION
## 진행 내용
api 서버에 들어오는 요청들에 대해 로그를 남길 수 있는 logger 미들웨어를 추가하였습니다. 
기존의 exception filter에 작성한 log 코드는 그대로 보존합니다. request가 들어왔을 때 info level에서 다음과 같이 로그를 남깁니다.
```
const { ip, method, originalUrl } = request;
const userAgent = request.get('user-agent');
request.on('close', () => {
    this.logger.info(`${method} ${originalUrl} - ${userAgent} ${ip}`);
});
```
