### PR TITLE
최신 refreshToken 무효화,  상품 목록 API 응답 내용 수정, swagger 수정

### DIFF
--- a/backend/src/auth/jwt/jwt.service.ts
+++ b/backend/src/auth/jwt/jwt.service.ts
@@ -3,7 +3,7 @@ import { JWTRepository } from './jwt.repository';
 import { Token } from 'src/entities/token.entity';
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
-import { REFRESH_TOKEN_SECRETS } from 'src/constants';
+import { INVALIDATED_REFRESHTOKEN, REFRESH_TOKEN_SECRETS } from 'src/constants';
 
 @Injectable()
 export class JWTService {
@@ -15,7 +15,7 @@ export class JWTService {
 
     async validateRefreshToken(userId: string, payload: string) {
         if (!(await this.isLatestRefreshToken(userId, payload))) {
-            this.jwtRepository.saveToken(userId, '');
+            this.jwtRepository.saveToken(userId, INVALIDATED_REFRESHTOKEN);
             throw new UnauthorizedException('이미 재발급된 refreshToken');
         }
     }

--- a/backend/src/auth/jwt/jwt.service.ts
+++ b/backend/src/auth/jwt/jwt.service.ts
@@ -13,18 +13,25 @@ export class JWTService {
         private jwtService: JwtService,
     ) {}
 
+    async validateRefreshToken(userId: string, payload: string) {
+        if (!(await this.isLatestRefreshToken(userId, payload))) {
+            this.jwtRepository.saveToken(userId, '');
+            throw new UnauthorizedException('이미 재발급된 refreshToken');
+        }
+    }
+
     async isLatestRefreshToken(userId: string, payload: string) {
         const tokenInfo = await this.findOne(userId);
         const latestRefreshToken = tokenInfo?.token;
         const token = this.jwtService.sign(payload, { secret: REFRESH_TOKEN_SECRETS });
         if (latestRefreshToken !== token) {
-            throw new UnauthorizedException('이미 재발급된 refreshToken');
+            return false;
         }
         return true;
     }
 
     async findOne(userId: string): Promise<Token | null> {
-        const refreshToken = await this.jwtRepository.findOne({ where: { userId } });
+        const refreshToken = await this.jwtRepository.findOne({ where: { userId: userId } });
         return refreshToken;
     }
 }

--- a/backend/src/auth/jwt/jwt.strategy.ts
+++ b/backend/src/auth/jwt/jwt.strategy.ts
@@ -36,7 +36,7 @@ export class RefreshJwtStrategy extends PassportStrategy(Strategy, 'refresh') {
         if (Date.now() >= payload.exp * 1000) {
             throw new HttpException('토큰이 만료되었습니다.', HttpStatus.GONE);
         }
-        await this.jwtService.isLatestRefreshToken(payload.id, payload);
+        await this.jwtService.validateRefreshToken(payload.id, payload);
         return { id: payload.id };
     }
 }

--- a/backend/src/constants.ts
+++ b/backend/src/constants.ts
@@ -15,3 +15,4 @@ export const REFRESH_TOKEN_SECRETS = process.env.REFRESH_TOKEN_SECRETS;
 export const OPEN_API_KEY_11ST = process.env.OPEN_API_KEY_11ST as string;
 export const BASE_URL_11ST = process.env.BASE_URL_11ST as string;
 export const MAX_TRACKING_RANK = parseInt(process.env.MAX_TRACKING_RANK || '50');
+export const INVALIDATED_REFRESHTOKEN = 'invalidate refreshToken';

--- a/backend/src/dto/auth.swagger.dto.ts
+++ b/backend/src/dto/auth.swagger.dto.ts
@@ -51,4 +51,14 @@ export class RefreshJWTSuccess {
         description: '메시지',
     })
     message: string;
+    @ApiProperty({
+        example: 'access example',
+        description: 'Access Token의 만료 기간은 2시간이다.',
+    })
+    accessToken: string;
+    @ApiProperty({
+        example: 'refresh example',
+        description: 'Refresh Token의 만료 기간은 2주이다.',
+    })
+    refreshToken: string;
 }

--- a/backend/src/dto/product.swagger.dto.ts
+++ b/backend/src/dto/product.swagger.dto.ts
@@ -123,7 +123,6 @@ const trackingProductListExample = [
         productName: 'Hallmark Keepsake 해리포터 마법의 분류 모자 크리스마스 장식',
         productCode: '5897533626',
         shop: '11번가',
-        shopUrl: 'https://www.11st.co.kr/products/6221602897',
         imageUrl: 'https://cdn.011st.com/11dims/strip/false/11src/asin/B091516D2Z/B.jpg?1700527038699',
         targetPrice: 30000,
         price: 20000,
@@ -132,7 +131,6 @@ const trackingProductListExample = [
         productName: 'Mercer Culinary 밀레니아 10인치 브레드 나이프 빵 칼 (M23210WBH)',
         productCode: '3534429539',
         shop: '11번가',
-        shopUrl: 'https://www.11st.co.kr/products/6221602897',
         imageUrl: 'https://cdn.011st.com/11dims/strip/false/11src/asin/B01HZ0YT2C/B.jpg?1700390686058',
         targetPrice: 20000,
         price: 15000,
@@ -159,44 +157,37 @@ export class GetTrackingListSuccess {
 
 const recommendProductListExample = [
     {
-        statusCode: 200,
-        message: '추천 상품 목록 조회 성공',
-        recommendList: [
-            {
-                productName: '갤럭시 GALAX 지포스 RTX 4060 1X D6 8GB',
-                productCode: '6221602897',
-                shop: '11번가',
-                imageUrl: 'https://cdn.011st.com/11dims/strip/false/11src/product/6221602897/B.jpg?556000000',
-                price: 1234,
-                rank: 1,
-            },
-            {
-                productName: '본사) 쿠쿠 화이트 3구 인덕션레인지 CIR-E301FW',
-                productCode: '3969500068',
-                shop: '11번가',
-                imageUrl:
-                    'https://cdn.011st.com/11dims/strip/false/11src/dl/v2/5/0/0/0/6/8/pNOcE/3969500068_154126549.jpg',
-                price: 1234,
-                rank: 2,
-            },
-            {
-                productName:
-                    '[카드추가할인] 삼성전자 SL-T1670FW 잉크젯 플러스S 정품 무한 복합기 프린터 복사 팩스 스캔 WiFi 무선 지원 잉크포함',
-                productCode: '4725944460',
-                shop: '11번가',
-                imageUrl: 'https://cdn.011st.com/11dims/strip/false/11src/product/4725944460/B.jpg?338000000',
-                price: 1234,
-                rank: 3,
-            },
-            {
-                productName: 'Hallmark Keepsake 해리포터 마법의 분류 모자 크리스마스 장식',
-                productCode: '5897533626',
-                shop: '11번가',
-                imageUrl: 'https://cdn.011st.com/11dims/strip/false/11src/asin/B091516D2Z/B.jpg?1700715151392',
-                price: 1234,
-                rank: 4,
-            },
-        ],
+        productName: '갤럭시 GALAX 지포스 RTX 4060 1X D6 8GB',
+        productCode: '6221602897',
+        shop: '11번가',
+        imageUrl: 'https://cdn.011st.com/11dims/strip/false/11src/product/6221602897/B.jpg?556000000',
+        price: 1234,
+        rank: 1,
+    },
+    {
+        productName: '본사) 쿠쿠 화이트 3구 인덕션레인지 CIR-E301FW',
+        productCode: '3969500068',
+        shop: '11번가',
+        imageUrl: 'https://cdn.011st.com/11dims/strip/false/11src/dl/v2/5/0/0/0/6/8/pNOcE/3969500068_154126549.jpg',
+        price: 1234,
+        rank: 2,
+    },
+    {
+        productName:
+            '[카드추가할인] 삼성전자 SL-T1670FW 잉크젯 플러스S 정품 무한 복합기 프린터 복사 팩스 스캔 WiFi 무선 지원 잉크포함',
+        productCode: '4725944460',
+        shop: '11번가',
+        imageUrl: 'https://cdn.011st.com/11dims/strip/false/11src/product/4725944460/B.jpg?338000000',
+        price: 1234,
+        rank: 3,
+    },
+    {
+        productName: 'Hallmark Keepsake 해리포터 마법의 분류 모자 크리스마스 장식',
+        productCode: '5897533626',
+        shop: '11번가',
+        imageUrl: 'https://cdn.011st.com/11dims/strip/false/11src/asin/B091516D2Z/B.jpg?1700715151392',
+        price: 1234,
+        rank: 4,
     },
 ];
 

--- a/backend/src/dto/product.tracking.dto.ts
+++ b/backend/src/dto/product.tracking.dto.ts
@@ -2,7 +2,6 @@ export class TrackingProductDto {
     productName: string;
     productCode: string;
     shop: string;
-    shopUrl: string;
     imageUrl: string;
     targetPrice: number;
     price: number;

--- a/backend/src/dto/user.swagger.dto.ts
+++ b/backend/src/dto/user.swagger.dto.ts
@@ -14,7 +14,7 @@ export class RegisterSuccess {
     message: string;
     @ApiProperty({
         example: 'access example',
-        description: 'Access Token의 만료 기간은 5분이다.',
+        description: 'Access Token의 만료 기간은 2시간이다.',
     })
     accessToken: string;
     @ApiProperty({
@@ -37,7 +37,7 @@ export class LoginSuccess {
     message: string;
     @ApiProperty({
         example: 'access example',
-        description: 'Access Token의 만료 기간은 5분이다.',
+        description: 'Access Token의 만료 기간은 2시간이다.',
     })
     accessToken: string;
     @ApiProperty({

--- a/backend/src/product/product.controller.ts
+++ b/backend/src/product/product.controller.ts
@@ -41,6 +41,7 @@ import {
     TrackingProductsNotFound,
     AddProductConflict,
     ProductDetailsSuccess,
+    AddProductSuccess,
 } from 'src/dto/product.swagger.dto';
 import { User } from 'src/entities/user.entity';
 import { AuthGuard } from '@nestjs/passport';
@@ -80,7 +81,7 @@ export class ProductController {
 
     @ApiOperation({ summary: '상품 추가 API', description: '상품을 추가한다' })
     @ApiBody({ type: ProductAddDto })
-    @ApiOkResponse({ type: VerifyUrlSuccess, description: '상품 추가 성공' })
+    @ApiOkResponse({ type: AddProductSuccess, description: '상품 추가 성공' })
     @ApiNotFoundResponse({ type: ProductCodeError, description: '상품 추가 실패' })
     @ApiBadRequestResponse({ type: RequestError, description: '잘못된 요청입니다.' })
     @ApiConflictResponse({ type: AddProductConflict, description: '이미 등록된 상품 존재' })

--- a/backend/src/product/product.service.ts
+++ b/backend/src/product/product.service.ts
@@ -53,12 +53,11 @@ export class ProductService {
             throw new HttpException('상품 목록을 찾을 수 없습니다.', HttpStatus.NOT_FOUND);
         }
         const trackingListInfo = trackingProductList.map(({ product, targetPrice }) => {
-            const { productName, productCode, shop, shopUrl, imageUrl } = product;
+            const { productName, productCode, shop, imageUrl } = product;
             return {
                 productName,
                 productCode,
                 shop,
-                shopUrl,
                 imageUrl,
                 targetPrice: targetPrice,
                 price: 1234, // 임시 더미 가격 데이터

--- a/backend/src/product/product.service.ts
+++ b/backend/src/product/product.service.ts
@@ -9,7 +9,8 @@ import { ProductRepository } from './product.repository';
 import { getProductInfo11st } from 'src/utils/openapi.11st';
 import { ProductDetailsDto } from 'src/dto/product.details.dto';
 
-const REGEXP_11ST = /http[s]?:\/\/(?:www\.|m\.)?11st\.co\.kr\/products\/(?:ma\/|m\/|pa\/)?([1-9]\d*)(?:\?.*)?(?:\/share)?/;
+const REGEXP_11ST =
+    /http[s]?:\/\/(?:www\.|m\.)?11st\.co\.kr\/products\/(?:ma\/|m\/|pa\/)?([1-9]\d*)(?:\?.*)?(?:\/share)?/;
 @Injectable()
 export class ProductService {
     constructor(

--- a/backend/src/product/product.service.ts
+++ b/backend/src/product/product.service.ts
@@ -9,7 +9,7 @@ import { ProductRepository } from './product.repository';
 import { getProductInfo11st } from 'src/utils/openapi.11st';
 import { ProductDetailsDto } from 'src/dto/product.details.dto';
 
-const REGEXP_11ST = /http[s]?:\/\/(?:www\.|m\.)?11st\.co\.kr\/products\/(?:ma\/|m\/)?([1-9]\d*)(?:\?.*)?(?:\/share)?/;
+const REGEXP_11ST = /http[s]?:\/\/(?:www\.|m\.)?11st\.co\.kr\/products\/(?:ma\/|m\/|pa\/)?([1-9]\d*)(?:\?.*)?(?:\/share)?/;
 @Injectable()
 export class ProductService {
     constructor(


### PR DESCRIPTION
Resolves #124
 
## 진행 내용
- [x] 이전 버전 refreshToken으로 accessToken 갱신 요청시, DB에 저장되어 있는 최신 refreshToken  토큰까지 무효화
- [x] 사용자가 추적중인 상품 목록 API 응답 요청에서 shopUrl 삭제
- [x] swagger 내용 최신화, 오류 수정 

```
this.jwtRepository.saveToken(userId, '');
```
이전 버전의 refreshToken으로 접근할 경우 사용자의 최신 refreshToken을 비어있는 string으로 업데이트하여 최신 refreshToken까지 무효화하는 기능을 추가하였습니다.

