### PR TITLE
상품 정보 cache 추가, 일정 기간 상품 정보 조회 추가

### DIFF
--- a/backend/src/constants.ts
+++ b/backend/src/constants.ts
@@ -18,3 +18,5 @@ export const MAX_TRACKING_RANK = parseInt(process.env.MAX_TRACKING_RANK || '50')
 export const INVALIDATED_REFRESHTOKEN = 'invalidate refreshToken';
 export const MONGODB_URL = process.env.MONGODB_URL as string;
 export const KR_OFFSET = 9 * 60 * 60 * 1000;
+export const THIRTY_DAYS = 30;
+export const NINETY_DAYS = 90;

--- a/backend/src/dto/price.data.dto.ts
+++ b/backend/src/dto/price.data.dto.ts
@@ -1,0 +1,5 @@
+export class PriceDataDto {
+    time: number;
+    price: number;
+    isSoldOut: boolean;
+}

--- a/backend/src/dto/product.details.dto.ts
+++ b/backend/src/dto/product.details.dto.ts
@@ -1,3 +1,5 @@
+import { PriceDataDto } from './price.data.dto';
+
 export class ProductDetailsDto {
     productName: string;
     shop: string;
@@ -7,4 +9,5 @@ export class ProductDetailsDto {
     targetPrice: number;
     lowestPrice: number;
     price: number;
+    priceData: PriceDataDto[];
 }

--- a/backend/src/product/product.controller.ts
+++ b/backend/src/product/product.controller.ts
@@ -121,7 +121,7 @@ export class ProductController {
     @ApiBadRequestResponse({ type: RequestError, description: '잘못된 요청입니다.' })
     @Get(':productCode')
     async getProductDetails(@Req() req: Request & { user: User }, @Param('productCode') productCode: string) {
-        const { productName, shop, imageUrl, rank, shopUrl, targetPrice, lowestPrice, price } =
+        const { productName, shop, imageUrl, rank, shopUrl, targetPrice, lowestPrice, price, priceData } =
             await this.productService.getProductDetails(req.user.id, productCode);
         return {
             statusCode: HttpStatus.OK,
@@ -135,6 +135,7 @@ export class ProductController {
             targetPrice,
             lowestPrice,
             price,
+            priceData,
         };
     }
 

--- a/backend/src/product/product.service.ts
+++ b/backend/src/product/product.service.ts
@@ -42,6 +42,7 @@ export class ProductService {
                         _id: '$productId',
                         price: { $first: '$price' },
                         isSoldOut: { $first: '$isSoldOut' },
+                        lowestPrice: { $min: '$price' },
                     },
                 },
             ])
@@ -50,6 +51,7 @@ export class ProductService {
             this.productDataCache.set(data._id, {
                 price: data.price,
                 isSoldOut: data.isSoldOut,
+                lowestPrice: data.lowestPrice,
             });
         });
     }
@@ -133,7 +135,7 @@ export class ProductService {
         const idx = ranklist.findIndex((product) => product.productId === selectProduct.id);
         const rank = idx === -1 ? idx : idx + 1;
         const priceData = await this.getPriceData(selectProduct.id, NINETY_DAYS);
-        const { price } = this.productDataCache.get(selectProduct.id);
+        const { price, lowestPrice } = this.productDataCache.get(selectProduct.id);
         return {
             productName: selectProduct.productName,
             shop: selectProduct.shop,
@@ -141,7 +143,7 @@ export class ProductService {
             rank: rank,
             shopUrl: selectProduct.shopUrl,
             targetPrice: trackingProduct ? trackingProduct.targetPrice : -1,
-            lowestPrice: 500,
+            lowestPrice: lowestPrice,
             price: price,
             priceData: priceData,
         };


### PR DESCRIPTION
## 진행 내용
- [x] 각각의 상품에 대한 현재 정보를 담고 있는 cache 구현
- [x] 일정 기간에 해당하는 상품 정보를 mongoDB에서 조회
- [x] 상품 상세 정보 API 응답에 90일 간의 상품 정보 추가

- 상품의 상세정보를 담고 있는 cache를 구현하여,  서버에서 상품 정보를 얻기 위해 DB까지 접근할 필요가 없도록 하였습니다. cache에는  상품 id별로 상품의 최신가격, 최저가, 품절 여부를 저장하고 있습니다.
- 상품 가격 그래프를 그리기 위한 정보를 일 단위로 mongoDB에서 조회할 수 있도록 구현하였습니다. 상품 상세 정보는 현재 90일 단위로 조회 되고 있습니다.