### PR TITLE
추천/추적 상품 목록 조회 API에서 가격 그래프 데이터 및 최신 가격 정보 동기화

### DIFF
--- a/backend/src/constants.ts
+++ b/backend/src/constants.ts
@@ -20,3 +20,4 @@ export const MONGODB_URL = process.env.MONGODB_URL as string;
 export const KR_OFFSET = 9 * 60 * 60 * 1000;
 export const THIRTY_DAYS = 30;
 export const NINETY_DAYS = 90;
+export const NO_CACHE = 0;

--- a/backend/src/dto/product.recommend.dto.ts
+++ b/backend/src/dto/product.recommend.dto.ts
@@ -1,11 +1,10 @@
 import { PriceDataDto } from './price.data.dto';
 
-export class TrackingProductDto {
+export class RecommendProductDto {
     productName: string;
     productCode: string;
     shop: string;
     imageUrl: string;
-    targetPrice: number;
     price: number;
     priceData: PriceDataDto[];
 }

--- a/backend/src/dto/product.swagger.dto.ts
+++ b/backend/src/dto/product.swagger.dto.ts
@@ -1,8 +1,8 @@
 import { HttpStatus } from '@nestjs/common';
 import { ApiProperty } from '@nestjs/swagger';
-import { ProductInfoDto } from './product.info.dto';
 import { TrackingProductDto } from './product.tracking.dto';
 import { ProductPriceDto } from './product.price.dto';
+import { RecommendProductDto } from './product.recommend.dto';
 
 export class VerifyUrlSuccess {
     @ApiProperty({
@@ -140,6 +140,7 @@ const trackingProductListExample = [
         imageUrl: 'https://cdn.011st.com/11dims/strip/false/11src/asin/B091516D2Z/B.jpg?1700527038699',
         targetPrice: 30000,
         price: 20000,
+        priceData: priceDataExample,
     },
     {
         productName: 'Mercer Culinary 밀레니아 10인치 브레드 나이프 빵 칼 (M23210WBH)',
@@ -148,6 +149,7 @@ const trackingProductListExample = [
         imageUrl: 'https://cdn.011st.com/11dims/strip/false/11src/asin/B01HZ0YT2C/B.jpg?1700390686058',
         targetPrice: 20000,
         price: 15000,
+        priceData: priceDataExample,
     },
 ];
 
@@ -177,6 +179,7 @@ const recommendProductListExample = [
         imageUrl: 'https://cdn.011st.com/11dims/strip/false/11src/product/6221602897/B.jpg?556000000',
         price: 1234,
         rank: 1,
+        priceData: priceDataExample,
     },
     {
         productName: '본사) 쿠쿠 화이트 3구 인덕션레인지 CIR-E301FW',
@@ -185,6 +188,7 @@ const recommendProductListExample = [
         imageUrl: 'https://cdn.011st.com/11dims/strip/false/11src/dl/v2/5/0/0/0/6/8/pNOcE/3969500068_154126549.jpg',
         price: 1234,
         rank: 2,
+        priceData: priceDataExample,
     },
     {
         productName:
@@ -194,6 +198,7 @@ const recommendProductListExample = [
         imageUrl: 'https://cdn.011st.com/11dims/strip/false/11src/product/4725944460/B.jpg?338000000',
         price: 1234,
         rank: 3,
+        priceData: priceDataExample,
     },
     {
         productName: 'Hallmark Keepsake 해리포터 마법의 분류 모자 크리스마스 장식',
@@ -202,6 +207,7 @@ const recommendProductListExample = [
         imageUrl: 'https://cdn.011st.com/11dims/strip/false/11src/asin/B091516D2Z/B.jpg?1700715151392',
         price: 1234,
         rank: 4,
+        priceData: priceDataExample,
     },
 ];
 
@@ -220,7 +226,7 @@ export class GetRecommendListSuccess {
         example: JSON.stringify(recommendProductListExample, null, 2),
         description: '추천 상품 목록',
     })
-    recommendList: ProductInfoDto[];
+    recommendList: RecommendProductDto[];
 }
 export class ProductDetailsSuccess {
     @ApiProperty({

--- a/backend/src/product/product.service.ts
+++ b/backend/src/product/product.service.ts
@@ -140,7 +140,7 @@ export class ProductService {
             where: { userId: userId, productId: selectProduct.id },
         });
         const ranklist = await this.trackingProductRepository.getRankingList();
-        const idx = ranklist.findIndex((product) => product.productId === selectProduct.id);
+        const idx = ranklist.findIndex(({ id }) => id === selectProduct.id);
         const rank = idx === -1 ? idx : idx + 1;
         const priceData = await this.getPriceData(selectProduct.id, NINETY_DAYS);
         const { price, lowestPrice } = this.productDataCache.get(selectProduct.id);

--- a/backend/src/product/trackingProduct.repository.ts
+++ b/backend/src/product/trackingProduct.repository.ts
@@ -24,7 +24,7 @@ export class TrackingProductRepository extends Repository<TrackingProduct> {
         const recommendList = await this.repository
             .createQueryBuilder('tracking_product')
             .select([
-                'tracking_product.productId as productId',
+                'tracking_product.productId as id',
                 'COUNT(tracking_product.userId) as userCount',
                 'product.productName as productName',
                 'product.productCode as productCode',
@@ -43,7 +43,7 @@ export class TrackingProductRepository extends Repository<TrackingProduct> {
     async getRankingList() {
         const rankList = await this.repository
             .createQueryBuilder('tracking_product')
-            .select('tracking_product.productId as productId')
+            .select('tracking_product.productId as id')
             .groupBy('tracking_product.productId')
             .orderBy('COUNT(tracking_product.userId)', 'DESC')
             .addOrderBy('MAX(tracking_product.productId)', 'DESC')


### PR DESCRIPTION
## 진행 내용

- [x] 추천/추적 상품 목록 조회 API에서 가격 그래프 데이터 및 최신 가격 정보 동기화
- [x] 관련 내용 swagger에 반영

기존에 더미 데이터로 존재하던 최신 가격 정보를 cache 값을 활용하여 동기화했습니다.
동시에 기존에 목록들을 불러올 때, `Promise.all`을 사용하여 병렬로 처리되도록 개선하였습니다.
다만, `Promise.all`로 처리를 하면 단 하나의 Promise만 Reject되어도 전부 Reject 처리가 되는 문제가 있습니다.