### PR TITLE
[상품 상세 화면] 선택한 기간에 따라 상품의 가격변동 추적

### DIFF
--- a/android/app/src/main/java/app/priceguard/data/graph/GraphDataConverter.kt
+++ b/android/app/src/main/java/app/priceguard/data/graph/GraphDataConverter.kt
@@ -1,24 +1,100 @@
 package app.priceguard.data.graph
 
 import app.priceguard.data.dto.PriceDataDTO
+import app.priceguard.materialchart.data.GraphMode
 
 class GraphDataConverter {
 
-    // TODO: 기간별로 데이터 필터링을 통해 해당 기간에 발생한 가격 변동만 추적하도록 구조 변경.
     fun toDataset(priceData: List<PriceDataDTO>?): List<ProductChartData> {
         priceData ?: return listOf()
         if (priceData.isEmpty()) {
             return listOf()
         }
+
         val dataList = mutableListOf<ProductChartData>()
         priceData.forEach { dto ->
             dto.time ?: return@forEach
             dto.price ?: return@forEach
             dto.isSoldOut ?: return@forEach
-            dataList.add(ProductChartData(dto.time / 1000, dto.price.toFloat(), dto.isSoldOut.not()))
+            dataList.add(
+                ProductChartData(
+                    dto.time / 1000,
+                    dto.price.toFloat(),
+                    dto.isSoldOut.not()
+                )
+            )
         }
-        val currentTime = (System.currentTimeMillis() / 1000).toFloat()
-        dataList.add(ProductChartData(currentTime, dataList.last().y, dataList.last().valid))
-        return dataList.toList().sortedBy { it.x }.filter { it.x <= currentTime }
+
+        return dataList.toList()
+    }
+
+    fun packWithEdgeData(
+        list: List<ProductChartData>,
+        period: GraphMode = GraphMode.DAY
+    ): List<ProductChartData> {
+        val currentTime = getCurrentTime()
+        val startTime = getStartTime(period, currentTime)
+        val sortedList = list.sortedBy { it.x }.filter { it.x in startTime..currentTime }
+
+        return if (sortedList.isEmpty()) {
+            listOf(
+                ProductChartData(
+                    startTime,
+                    list.last().y,
+                    list.last().valid
+                )
+            ).plus(
+                ProductChartData(
+                    currentTime,
+                    list.last().y,
+                    list.last().valid
+                )
+            )
+        } else {
+            listOf(
+                ProductChartData(
+                    startTime,
+                    sortedList.first().y,
+                    sortedList.first().valid
+                )
+            ).plus(sortedList).plus(
+                ProductChartData(
+                    currentTime,
+                    sortedList.last().y,
+                    sortedList.last().valid
+                )
+            )
+        }
+    }
+
+    private fun getStartTime(period: GraphMode, currentTime: Float = getCurrentTime()): Float {
+        return when (period) {
+            GraphMode.DAY -> {
+                currentTime - DAY
+            }
+
+            GraphMode.WEEK -> {
+                currentTime - WEEK
+            }
+
+            GraphMode.MONTH -> {
+                currentTime - MONTH
+            }
+
+            GraphMode.QUARTER -> {
+                currentTime - QUARTER
+            }
+        }
+    }
+
+    private fun getCurrentTime(): Float {
+        return (System.currentTimeMillis() / 1000).toFloat()
+    }
+
+    companion object {
+        const val DAY = 86400
+        const val WEEK = DAY * 7
+        const val MONTH = DAY * 31
+        const val QUARTER = MONTH * 3
     }
 }

--- a/android/app/src/main/java/app/priceguard/data/graph/ProductChartDataset.kt
+++ b/android/app/src/main/java/app/priceguard/data/graph/ProductChartDataset.kt
@@ -1,6 +1,5 @@
 package app.priceguard.data.graph
 
-import app.priceguard.materialchart.data.ChartData
 import app.priceguard.materialchart.data.ChartDataset
 import app.priceguard.materialchart.data.GraphMode
 import app.priceguard.materialchart.data.GridLine
@@ -10,6 +9,6 @@ data class ProductChartDataset(
     override val showYAxis: Boolean,
     override val isInteractive: Boolean,
     override val graphMode: GraphMode,
-    override val data: List<ChartData>,
+    override val data: List<ProductChartData>,
     override val gridLines: List<GridLine>
 ) : ChartDataset

--- a/android/app/src/main/java/app/priceguard/ui/detail/ProductDetailViewModel.kt
+++ b/android/app/src/main/java/app/priceguard/ui/detail/ProductDetailViewModel.kt
@@ -3,6 +3,8 @@ package app.priceguard.ui.detail
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.priceguard.data.dto.ProductErrorState
+import app.priceguard.data.graph.GraphDataConverter
+import app.priceguard.data.graph.ProductChartData
 import app.priceguard.data.graph.ProductChartDataset
 import app.priceguard.data.network.ProductRepositoryResult
 import app.priceguard.data.repository.ProductRepository
@@ -20,8 +22,10 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 @HiltViewModel
-class ProductDetailViewModel @Inject constructor(val productRepository: ProductRepository) :
-    ViewModel() {
+class ProductDetailViewModel @Inject constructor(
+    private val productRepository: ProductRepository,
+    private val graphDataConverter: GraphDataConverter
+) : ViewModel() {
 
     data class ProductDetailUIState(
         val isTracking: Boolean = false,
@@ -38,7 +42,6 @@ class ProductDetailViewModel @Inject constructor(val productRepository: ProductR
         val formattedPrice: String = "",
         val formattedTargetPrice: String = "",
         val formattedLowestPrice: String = "",
-        val chartPeriod: GraphMode = GraphMode.DAY,
         val chartData: ProductChartDataset? = null
     )
 
@@ -53,6 +56,7 @@ class ProductDetailViewModel @Inject constructor(val productRepository: ProductR
     }
 
     lateinit var productCode: String
+    private var productGraphData: List<ProductChartData> = listOf()
 
     private var _event: MutableSharedFlow<ProductDetailEvent> = MutableSharedFlow()
     val event: SharedFlow<ProductDetailEvent> = _event.asSharedFlow()
@@ -91,6 +95,7 @@ class ProductDetailViewModel @Inject constructor(val productRepository: ProductR
 
             when (result) {
                 is ProductRepositoryResult.Success -> {
+                    productGraphData = result.data.priceData
                     _state.update {
                         it.copy(
                             isReady = true,
@@ -112,13 +117,12 @@ class ProductDetailViewModel @Inject constructor(val productRepository: ProductR
                                 )
                             },
                             formattedLowestPrice = formatPrice(result.data.lowestPrice),
-                            chartPeriod = GraphMode.DAY,
                             chartData = ProductChartDataset(
                                 showXAxis = true,
                                 showYAxis = true,
                                 isInteractive = true,
                                 graphMode = GraphMode.DAY,
-                                data = result.data.priceData,
+                                data = graphDataConverter.packWithEdgeData(result.data.priceData),
                                 gridLines = listOf()
                             )
                         )
@@ -145,15 +149,18 @@ class ProductDetailViewModel @Inject constructor(val productRepository: ProductR
     }
 
     fun changePeriod(period: GraphMode) {
+        if (productGraphData.isEmpty()) {
+            return
+        }
+
         _state.update {
             it.copy(
-                chartPeriod = period,
                 chartData = ProductChartDataset(
                     showXAxis = true,
                     showYAxis = true,
                     isInteractive = true,
                     graphMode = period,
-                    data = it.chartData?.data ?: listOf(),
+                    data = graphDataConverter.packWithEdgeData(productGraphData, period),
                     gridLines = listOf()
                 )
             )

--- a/android/app/src/main/java/app/priceguard/ui/home/ProductSummaryAdapter.kt
+++ b/android/app/src/main/java/app/priceguard/ui/home/ProductSummaryAdapter.kt
@@ -116,7 +116,7 @@ class ProductSummaryAdapter :
                 showXAxis = false,
                 showYAxis = false,
                 isInteractive = false,
-                graphMode = GraphMode.DAY,
+                graphMode = GraphMode.QUARTER,
                 data = data,
                 gridLines = listOf()
             )

--- a/android/app/src/main/java/app/priceguard/ui/home/list/ProductListViewModel.kt
+++ b/android/app/src/main/java/app/priceguard/ui/home/list/ProductListViewModel.kt
@@ -3,8 +3,10 @@ package app.priceguard.ui.home.list
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.priceguard.data.dto.ProductErrorState
+import app.priceguard.data.graph.GraphDataConverter
 import app.priceguard.data.network.ProductRepositoryResult
 import app.priceguard.data.repository.ProductRepository
+import app.priceguard.materialchart.data.GraphMode
 import app.priceguard.ui.home.ProductSummary.UserProductSummary
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -19,7 +21,8 @@ import kotlinx.coroutines.launch
 
 @HiltViewModel
 class ProductListViewModel @Inject constructor(
-    private val productRepository: ProductRepository
+    private val productRepository: ProductRepository,
+    private val graphDataConverter: GraphDataConverter
 ) : ViewModel() {
 
     private var _isRefreshing: MutableStateFlow<Boolean> = MutableStateFlow(false)
@@ -49,7 +52,7 @@ class ProductListViewModel @Inject constructor(
                             data.productName,
                             data.price,
                             data.productCode,
-                            data.priceData,
+                            graphDataConverter.packWithEdgeData(data.priceData, GraphMode.QUARTER),
                             calculateDiscountRate(data.targetPrice, data.price),
                             true
                         )

--- a/android/app/src/main/java/app/priceguard/ui/home/recommend/RecommendedProductViewModel.kt
+++ b/android/app/src/main/java/app/priceguard/ui/home/recommend/RecommendedProductViewModel.kt
@@ -3,8 +3,10 @@ package app.priceguard.ui.home.recommend
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.priceguard.data.dto.ProductErrorState
+import app.priceguard.data.graph.GraphDataConverter
 import app.priceguard.data.network.ProductRepositoryResult
 import app.priceguard.data.repository.ProductRepository
+import app.priceguard.materialchart.data.GraphMode
 import app.priceguard.ui.home.ProductSummary.RecommendedProductSummary
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -18,7 +20,8 @@ import kotlinx.coroutines.launch
 
 @HiltViewModel
 class RecommendedProductViewModel @Inject constructor(
-    private val productRepository: ProductRepository
+    private val productRepository: ProductRepository,
+    private val graphDataConverter: GraphDataConverter
 ) : ViewModel() {
 
     sealed class RecommendedProductEvent {
@@ -53,7 +56,7 @@ class RecommendedProductViewModel @Inject constructor(
                             data.productName,
                             data.price,
                             data.productCode,
-                            data.priceData,
+                            graphDataConverter.packWithEdgeData(data.priceData, GraphMode.QUARTER),
                             data.rank
                         )
                     }


### PR DESCRIPTION
- Resolves #151 

## 진행 내용

converter가 다음의 역할을 하도록 변경했습니다.
1. 먼저 서버에서 받아온 데이터셋을 뷰모델에서 사용하기 용이하게 편집하여 전달한다.
2. 이후 기간에 따라 양 끝에 데이터셋을 추가하도록 하는 기능을 추가해 그리기 쉽게 만든다.

- [ ] ProductChartDataset이 ProductChartData 리스트를 받도록 수정
- [ ] converter 변경
- [ ] 뷰모델 & 뷰 적용


## 스크린샷 (선택)

https://github.com/boostcampwm2023/and09-PriceGuard/assets/37584805/9fd7ebb0-f2b7-41a7-900b-20693787570f


