### PR TITLE
회원가입 이름 길이 제한, 비밀번호 정규식 수정

### DIFF
--- a/android/app/src/main/java/app/priceguard/ui/login/LoginViewModel.kt
+++ b/android/app/src/main/java/app/priceguard/ui/login/LoginViewModel.kt
@@ -41,7 +41,7 @@ class LoginViewModel @Inject constructor(
     private val emailPattern =
         """^[\w.+-]+@((?!-)[A-Za-z0-9-]{1,63}(?<!-)\.)+[A-Za-z]{2,6}$""".toRegex()
     private val passwordPattern =
-        """^(?=[A-Za-z\d!@#$%^&*]*\d)(?=[A-Za-z\d!@#$%^&*]*[a-z])(?=[A-Za-z\d!@#$%^&*]*[A-Z])(?=[A-Za-z\d!@#$%^&*]*[!@#$%^&*])[A-Za-z\d!@#$%^&*]{8,16}$""".toRegex()
+        """^(?=[A-Za-z\d!@#$%^&*()_+={};:'"~`,.?<>|\-\[\]\\/]*\d)(?=[A-Za-z\d!@#$%^&*()_+={};:'"~`,.?<>|\-\[\]\\/]*[a-z])(?=[A-Za-z\d!@#$%^&*()_+={};:'"~`,.?<>|\-\[\]\\/]*[A-Z])(?=[A-Za-z\d!@#$%^&*()_+={};:'"~`,.?<>|\-\[\]\\/]*[A-Za-z\d!@#$%^&*()_+={};:'"~`,.?<>|\-\[\]\\/])[A-Za-z\d!@#$%^&*()_+={};:'"~`,.?<>|\-\[\]\\/]{8,16}$""".toRegex()
 
     private var _event = MutableSharedFlow<LoginEvent>()
     val event: SharedFlow<LoginEvent> = _event.asSharedFlow()

--- a/android/app/src/main/java/app/priceguard/ui/signup/SignupActivity.kt
+++ b/android/app/src/main/java/app/priceguard/ui/signup/SignupActivity.kt
@@ -137,7 +137,7 @@ class SignupActivity : AppCompatActivity() {
     private fun updateNameTextFieldUI(state: SignupUIState) {
         when (state.isNameError) {
             true -> {
-                binding.tilSignupName.error = getString(R.string.name_required)
+                binding.tilSignupName.error = getString(R.string.invalid_name)
             }
 
             else -> {

--- a/android/app/src/main/java/app/priceguard/ui/signup/SignupViewModel.kt
+++ b/android/app/src/main/java/app/priceguard/ui/signup/SignupViewModel.kt
@@ -135,7 +135,7 @@ class SignupViewModel @Inject constructor(
     }
 
     private fun isValidName(): Boolean {
-        return _state.value.name.isNotBlank()
+        return _state.value.name.isNotBlank() && _state.value.name.length <= 16
     }
 
     private fun isValidEmail(): Boolean {

--- a/android/app/src/main/java/app/priceguard/ui/signup/SignupViewModel.kt
+++ b/android/app/src/main/java/app/priceguard/ui/signup/SignupViewModel.kt
@@ -48,7 +48,7 @@ class SignupViewModel @Inject constructor(
     private val emailPattern =
         """^[\w.+-]+@((?!-)[A-Za-z0-9-]{1,63}(?<!-)\.)+[A-Za-z]{2,6}$""".toRegex()
     private val passwordPattern =
-        """^(?=[A-Za-z\d!@#$%^&*]*\d)(?=[A-Za-z\d!@#$%^&*]*[a-z])(?=[A-Za-z\d!@#$%^&*]*[A-Z])(?=[A-Za-z\d!@#$%^&*]*[!@#$%^&*])[A-Za-z\d!@#$%^&*]{8,16}$""".toRegex()
+        """^(?=[A-Za-z\d!@#$%^&*()_+={};:'"~`,.?<>|\-\[\]\\/]*\d)(?=[A-Za-z\d!@#$%^&*()_+={};:'"~`,.?<>|\-\[\]\\/]*[a-z])(?=[A-Za-z\d!@#$%^&*()_+={};:'"~`,.?<>|\-\[\]\\/]*[A-Z])(?=[A-Za-z\d!@#$%^&*()_+={};:'"~`,.?<>|\-\[\]\\/]*[A-Za-z\d!@#$%^&*()_+={};:'"~`,.?<>|\-\[\]\\/])[A-Za-z\d!@#$%^&*()_+={};:'"~`,.?<>|\-\[\]\\/]{8,16}$""".toRegex()
 
     private val _state: MutableStateFlow<SignupUIState> = MutableStateFlow(SignupUIState())
     val state: StateFlow<SignupUIState> = _state.asStateFlow()

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -15,7 +15,7 @@
     <string name="name_required">이름은 필수 입력 사항입니다.</string>
     <string name="invalid_email">유효하지 않은 이메일입니다.</string>
     <string name="valid_email">유효한 이메일입니다.</string>
-    <string name="invalid_password">비밀번호는 영문 대소문자와 특수문자가 포함된 8~16자 사이어야 합니다.</string>
+    <string name="invalid_password">비밀번호는 영문 대소문자, 숫자, 특수문자가 포함된 8~16자 사이어야 합니다.</string>
     <string name="valid_password">적합한 비밀번호입니다.</string>
     <string name="password_mismatch">비밀번호가 일치하지 않습니다.</string>
     <string name="password_match">비밀번호가 일치합니다.</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -12,7 +12,7 @@
     <string name="notification_setting">알림 설정</string>
     <string name="theme_setting">테마 설정</string>
     <string name="logout">로그아웃</string>
-    <string name="name_required">이름은 필수 입력 사항입니다.</string>
+    <string name="invalid_name">이름은 16자 이내로 입력해 주세요.</string>
     <string name="invalid_email">유효하지 않은 이메일입니다.</string>
     <string name="valid_email">유효한 이메일입니다.</string>
     <string name="invalid_password">비밀번호는 영문 대소문자, 숫자, 특수문자가 포함된 8~16자 사이어야 합니다.</string>


### PR DESCRIPTION
## 진행 내용

- [x] DB상 이름을 16자만 입력할 수 있어 회원가입 시 이름 길이에 제한을 추가
- [x] 비밀번호 정규식에서 키보드에서 사용할 수 있는 특수문자 전부 추가
- [x] 해당 비밀번호 정규식에 대한 안내 수정

정규식
```
^(?=[A-Za-z\d!@#$%^&*()_+={};:'"~`,.?<>|\-\[\]\\/]*\d)(?=[A-Za-z\d!@#$%^&*()_+={};:'"~`,.?<>|\-\[\]\\/]*[a-z])(?=[A-Za-z\d!@#$%^&*()_+={};:'"~`,.?<>|\-\[\]\\/]*[A-Z])(?=[A-Za-z\d!@#$%^&*()_+={};:'"~`,.?<>|\-\[\]\\/]*[A-Za-z\d!@#$%^&*()_+={};:'"~`,.?<>|\-\[\]\\/])[A-Za-z\d!@#$%^&*()_+={};:'"~`,.?<>|\-\[\]\\/]{8,16}$
```

## 스크린샷 (선택)


<img width="504" alt="image" src="https://github.com/boostcampwm2023/and09-PriceGuard/assets/27392567/d704ea43-3d16-47a8-81a7-ccc0f320e000">

<img width="1018" alt="image" src="https://github.com/boostcampwm2023/and09-PriceGuard/assets/27392567/a2cdfe9a-ed7b-4d1a-bff1-e0079007c8a1">


