### PR TITLE
다름 앱에서 공유 시 상품 추가 화면으로 이동

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.PriceGuard"
         tools:targetApi="34">
+
         <activity
             android:name=".ui.splash.SplashScreenActivity"
             android:exported="true">
@@ -23,37 +24,57 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
         <activity
             android:name=".ui.intro.IntroActivity"
             android:exported="false" />
+
         <activity
             android:name=".ui.login.LoginActivity"
             android:exported="false" />
+
         <activity
             android:name=".ui.signup.SignupActivity"
             android:exported="false" />
+
         <activity
             android:name=".ui.home.HomeActivity"
             android:exported="false" />
+
         <activity
             android:name=".ui.additem.AddItemActivity"
-            android:exported="false" />
+            android:exported="true">
+
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:mimeType="text/plain" />
+            </intent-filter>
+        </activity>
+
         <activity
             android:name=".ui.detail.DetailActivity"
-            android:launchMode="singleTask"
-            android:exported="true">
+            android:exported="true"
+            android:launchMode="singleTask">
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
+
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="priceguard"
-                    android:host="product" />
-            </intent-filter>
 
+                <data
+                    android:host="product"
+                    android:scheme="priceguard" />
+            </intent-filter>
         </activity>
+
         <activity
             android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
             android:theme="@style/Theme.PriceGuard.WithActionBar" />
+
         <activity
             android:name="com.google.android.gms.oss.licenses.OssLicensesActivity"
             android:theme="@style/Theme.PriceGuard.WithActionBar" />

--- a/android/app/src/main/java/app/priceguard/ui/additem/AddItemActivity.kt
+++ b/android/app/src/main/java/app/priceguard/ui/additem/AddItemActivity.kt
@@ -1,8 +1,10 @@
 package app.priceguard.ui.additem
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.fragment.NavHostFragment
+import app.priceguard.R
 import app.priceguard.databinding.ActivityAddItemBinding
 import app.priceguard.ui.additem.link.RegisterItemLinkFragmentDirections
 import dagger.hilt.android.AndroidEntryPoint
@@ -21,12 +23,19 @@ class AddItemActivity : AppCompatActivity() {
     }
 
     private fun setStartDestination() {
-        if (intent.hasExtra("productCode") &&
+        val navController = binding.fcvAddItem.getFragment<NavHostFragment>().navController
+
+        if (intent?.action == Intent.ACTION_SEND && intent.type == "text/plain") {
+            intent.getStringExtra(Intent.EXTRA_TEXT)?.let { data ->
+                val bundle = Bundle()
+                bundle.putString("link", data)
+                navController.navigate(R.id.registerItemLinkFragment, bundle)
+            }
+        } else if (intent.hasExtra("productCode") &&
             intent.hasExtra("productTitle") &&
             intent.hasExtra("productPrice") &&
             intent.hasExtra("isAdding")
         ) {
-            val navController = binding.fcvAddItem.getFragment<NavHostFragment>().navController
             val action =
                 RegisterItemLinkFragmentDirections.actionRegisterItemLinkFragmentToSetTargetPriceFragment(
                     intent.getStringExtra("productCode") ?: "",

--- a/android/app/src/main/java/app/priceguard/ui/additem/link/RegisterItemLinkFragment.kt
+++ b/android/app/src/main/java/app/priceguard/ui/additem/link/RegisterItemLinkFragment.kt
@@ -41,8 +41,18 @@ class RegisterItemLinkFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         binding.lifecycleOwner = viewLifecycleOwner
         binding.viewModel = registerItemLinkViewModel
+
+        setLinkText()
+
         initCollector()
         initEvent()
+    }
+
+    private fun setLinkText() {
+        arguments?.getString("link")?.let { linkText ->
+            binding.etRegisterItemLink.setText(linkText)
+            registerItemLinkViewModel.updateLink(linkText)
+        }
     }
 
     private fun initCollector() {

--- a/android/app/src/main/java/app/priceguard/ui/additem/link/RegisterItemLinkFragment.kt
+++ b/android/app/src/main/java/app/priceguard/ui/additem/link/RegisterItemLinkFragment.kt
@@ -1,9 +1,11 @@
 package app.priceguard.ui.additem.link
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.NavController
@@ -13,6 +15,7 @@ import app.priceguard.R
 import app.priceguard.data.repository.product.ProductErrorState
 import app.priceguard.data.repository.token.TokenRepository
 import app.priceguard.databinding.FragmentRegisterItemLinkBinding
+import app.priceguard.ui.home.HomeActivity
 import app.priceguard.ui.util.lifecycle.repeatOnStarted
 import app.priceguard.ui.util.ui.showPermissionDeniedDialog
 import dagger.hilt.android.AndroidEntryPoint
@@ -42,6 +45,7 @@ class RegisterItemLinkFragment : Fragment() {
         binding.lifecycleOwner = viewLifecycleOwner
         binding.viewModel = registerItemLinkViewModel
 
+        setBackPressedCallback()
         setLinkText()
 
         initCollector()
@@ -53,6 +57,22 @@ class RegisterItemLinkFragment : Fragment() {
             binding.etRegisterItemLink.setText(linkText)
             registerItemLinkViewModel.updateLink(linkText)
         }
+    }
+
+    private fun setBackPressedCallback() {
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+            goToHomeActivity()
+        }
+    }
+
+    private fun goToHomeActivity() {
+        val activityIntent = requireActivity().intent
+        if (activityIntent?.action == Intent.ACTION_SEND) {
+            val intent = Intent(requireActivity(), HomeActivity::class.java)
+            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            startActivity(intent)
+        }
+        requireActivity().finish()
     }
 
     private fun initCollector() {

--- a/android/app/src/main/java/app/priceguard/ui/additem/link/RegisterItemLinkViewModel.kt
+++ b/android/app/src/main/java/app/priceguard/ui/additem/link/RegisterItemLinkViewModel.kt
@@ -21,7 +21,7 @@ class RegisterItemLinkViewModel
     data class RegisterLinkUIState(
         val link: String = "",
         val product: ProductVerifyResult? = null,
-        val isNextReady: Boolean = true,
+        val isNextReady: Boolean = false,
         val isLinkError: Boolean = false
     )
 

--- a/android/app/src/main/java/app/priceguard/ui/additem/setprice/SetTargetPriceFragment.kt
+++ b/android/app/src/main/java/app/priceguard/ui/additem/setprice/SetTargetPriceFragment.kt
@@ -1,5 +1,6 @@
 package app.priceguard.ui.additem.setprice
 
+import android.content.Intent
 import android.os.Bundle
 import android.text.Editable
 import android.view.LayoutInflater
@@ -15,6 +16,7 @@ import app.priceguard.data.repository.product.ProductErrorState
 import app.priceguard.data.repository.token.TokenRepository
 import app.priceguard.databinding.FragmentSetTargetPriceBinding
 import app.priceguard.ui.additem.setprice.SetTargetPriceViewModel.SetTargetPriceEvent
+import app.priceguard.ui.home.HomeActivity
 import app.priceguard.ui.util.lifecycle.repeatOnStarted
 import app.priceguard.ui.util.ui.showPermissionDeniedDialog
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -212,10 +214,20 @@ class SetTargetPriceFragment : Fragment() {
         MaterialAlertDialogBuilder(requireActivity(), R.style.ThemeOverlay_App_MaterialAlertDialog)
             .setTitle(title)
             .setMessage(message)
-            .setPositiveButton(R.string.confirm) { _, _ -> requireActivity().finish() }
-            .setOnDismissListener { requireActivity().finish() }
+            .setPositiveButton(R.string.confirm) { _, _ -> goToHomeActivity() }
+            .setOnDismissListener { goToHomeActivity() }
             .create()
             .show()
+    }
+
+    private fun goToHomeActivity() {
+        val activityIntent = requireActivity().intent
+        if (activityIntent?.action == Intent.ACTION_SEND) {
+            val intent = Intent(requireActivity(), HomeActivity::class.java)
+            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            startActivity(intent)
+        }
+        requireActivity().finish()
     }
 
     private fun FragmentSetTargetPriceBinding.updateSlideValueWithPrice(

--- a/android/app/src/main/java/app/priceguard/ui/detail/DetailActivity.kt
+++ b/android/app/src/main/java/app/priceguard/ui/detail/DetailActivity.kt
@@ -258,10 +258,8 @@ class DetailActivity : AppCompatActivity() {
             val intent = Intent(this@DetailActivity, HomeActivity::class.java)
             intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
             startActivity(intent)
-            finish()
-        } else {
-            finish()
         }
+        finish()
     }
 
     private fun showConfirmationDialog(


### PR DESCRIPTION
- Resolves #6 

## 진행 내용

- [x] 텍스트 외부 공유시 상품 추가 화면으로 이동
- [x] 공유한 텍스트 자동 입력
- [x] 암시적 인텐트로 앱 실행했을 때 뒤로가기 클릭 시, 상품 등록 완료 시 홈 화면으로 이동

## 스크린샷 (선택)

https://github.com/boostcampwm2023/and09-PriceGuard/assets/83055885/94d29d1c-0f1f-4020-9fb1-3348d20ed0b6


링크가 아닌 그냥 텍스트도 공유가 되는데 intent filter에서는 구분이 불가능한 것 같습니다