### PR TITLE
[버그] 일 그래프에서 이전 데이터가 잘리던 현상 수정

### DIFF
--- a/android/app/src/main/java/app/priceguard/data/GraphDataConverter.kt
+++ b/android/app/src/main/java/app/priceguard/data/GraphDataConverter.kt
@@ -35,24 +35,31 @@ class GraphDataConverter {
     ): List<ProductChartData> {
         val currentTime = getCurrentTime()
         val startTime = getStartTime(period, currentTime)
-        val sortedList = list.sortedBy { it.x }.filter { it.x in startTime..currentTime }
+        val sortedList = list.sortedBy { it.x }
+        val filteredList = sortedList.filter { it.x in startTime..currentTime }
+        val sievedList = sortedList.filter { it.x !in startTime..currentTime }
+        val startData = if (sievedList.none()) {
+            list.first()
+        } else {
+            sievedList.last()
+        }
 
-        return if (sortedList.isEmpty()) {
+        return if (filteredList.isEmpty()) {
             listOf(
-                ProductChartData(startTime, list.last().y, list.last().valid),
+                ProductChartData(startTime, startData.y, startData.valid),
                 ProductChartData(currentTime, list.last().y, list.last().valid)
             )
         } else {
             listOf(
                 ProductChartData(
                     startTime,
-                    sortedList.first().y,
-                    sortedList.first().valid
+                    startData.y,
+                    startData.valid
                 )
-            ) + sortedList + ProductChartData(
+            ) + filteredList + ProductChartData(
                 currentTime,
-                sortedList.last().y,
-                sortedList.last().valid
+                filteredList.last().y,
+                filteredList.last().valid
             )
         }
     }


### PR DESCRIPTION
## 진행 내용

일 그래프에서 이전 데이터가 잘리던 현상 수정


## 스크린샷 (선택)

before
<img src="https://github.com/boostcampwm2023/and09-PriceGuard/assets/37584805/e9d94395-a601-4586-9171-49d76c6a2879" width="300" height="600"/>
after
<img src="https://github.com/boostcampwm2023/and09-PriceGuard/assets/37584805/6b6a7e35-3bd6-4b98-b011-fac1a64caff8" width="300" height="600"/>
