### PR TITLE
다이나믹 테마 적용이 불가능한 OS면 다이나믹 테마 설정 View 비활성화

### DIFF
--- a/android/app/src/main/java/app/priceguard/ui/home/theme/ThemeDialogFragment.kt
+++ b/android/app/src/main/java/app/priceguard/ui/home/theme/ThemeDialogFragment.kt
@@ -30,7 +30,7 @@ class ThemeDialogFragment : DialogFragment() {
         _binding = FragmentThemeDialogBinding.inflate(requireActivity().layoutInflater)
         val view = binding.root
 
-        setCheckedButton(binding)
+        setCheckedButton()
         checkDynamicThemeSupport()
 
         return MaterialAlertDialogBuilder(
@@ -108,7 +108,7 @@ class ThemeDialogFragment : DialogFragment() {
         }
     }
 
-    private fun setCheckedButton(binding: FragmentThemeDialogBinding) {
+    private fun setCheckedButton() {
         lifecycleScope.launch {
             val dynamicColorMode = configDataSource.getDynamicMode()
             val darkMode = configDataSource.getDarkMode()

--- a/android/app/src/main/java/app/priceguard/ui/home/theme/ThemeDialogFragment.kt
+++ b/android/app/src/main/java/app/priceguard/ui/home/theme/ThemeDialogFragment.kt
@@ -1,6 +1,7 @@
 package app.priceguard.ui.home.theme
 
 import android.app.Dialog
+import android.os.Build
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.fragment.app.DialogFragment
@@ -22,13 +23,15 @@ class ThemeDialogFragment : DialogFragment() {
 
     @Inject
     lateinit var configDataSource: ConfigDataSource
+    private var _binding: FragmentThemeDialogBinding? = null
+    private val binding get() = _binding!!
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val binding: FragmentThemeDialogBinding =
-            FragmentThemeDialogBinding.inflate(requireActivity().layoutInflater)
+        _binding = FragmentThemeDialogBinding.inflate(requireActivity().layoutInflater)
         val view = binding.root
 
         setCheckedButton(binding)
+        checkDynamicThemeSupport()
 
         return MaterialAlertDialogBuilder(
             requireActivity(),
@@ -78,6 +81,20 @@ class ThemeDialogFragment : DialogFragment() {
                 dismiss()
             }
         }.create()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun checkDynamicThemeSupport() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            // Disable Dynamic Theme Radio Group
+            (0 until binding.rgDynamicColor.childCount).forEach { idx ->
+                binding.rgDynamicColor.getChildAt(idx).isEnabled = false
+            }
+        }
     }
 
     private fun saveTheme(dynamicMode: Int, darkMode: Int) {

--- a/android/app/src/main/java/app/priceguard/ui/home/theme/ThemeDialogFragment.kt
+++ b/android/app/src/main/java/app/priceguard/ui/home/theme/ThemeDialogFragment.kt
@@ -39,44 +39,9 @@ class ThemeDialogFragment : DialogFragment() {
         ).apply {
             setView(view)
             setPositiveButton(R.string.confirm) { _, _ ->
-                val dynamicMode = when (binding.rgDynamicColor.checkedRadioButtonId) {
-                    R.id.rb_yes -> {
-                        DynamicColors.applyToActivitiesIfAvailable(requireActivity().application)
-                        requireActivity().recreate()
-                        PriceGuardApp.MODE_DYNAMIC
-                    }
+                val dynamicMode = applyDynamicMode()
+                val darkMode = applyDarkMode()
 
-                    else -> {
-                        DynamicColors.applyToActivitiesIfAvailable(
-                            requireActivity().application,
-                            DynamicColorsOptions.Builder()
-                                .setThemeOverlay(R.style.Theme_PriceGuard).build()
-                        )
-                        requireActivity().recreate()
-                        PriceGuardApp.MODE_DYNAMIC_NO
-                    }
-                }
-
-                val darkMode = when (binding.rgDarkMode.checkedRadioButtonId) {
-                    R.id.rb_system -> {
-                        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
-                        PriceGuardApp.MODE_SYSTEM
-                    }
-
-                    R.id.rb_light -> {
-                        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
-                        PriceGuardApp.MODE_LIGHT
-                    }
-
-                    R.id.rb_dark -> {
-                        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
-                        PriceGuardApp.MODE_DARK
-                    }
-
-                    else -> {
-                        PriceGuardApp.MODE_SYSTEM
-                    }
-                }
                 saveTheme(dynamicMode, darkMode)
                 dismiss()
             }
@@ -86,6 +51,45 @@ class ThemeDialogFragment : DialogFragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    private fun applyDynamicMode() = when (binding.rgDynamicColor.checkedRadioButtonId) {
+        R.id.rb_yes -> {
+            DynamicColors.applyToActivitiesIfAvailable(requireActivity().application)
+            requireActivity().recreate()
+            PriceGuardApp.MODE_DYNAMIC
+        }
+
+        else -> {
+            DynamicColors.applyToActivitiesIfAvailable(
+                requireActivity().application,
+                DynamicColorsOptions.Builder()
+                    .setThemeOverlay(R.style.Theme_PriceGuard).build()
+            )
+            requireActivity().recreate()
+            PriceGuardApp.MODE_DYNAMIC_NO
+        }
+    }
+
+    private fun applyDarkMode() = when (binding.rgDarkMode.checkedRadioButtonId) {
+        R.id.rb_system -> {
+            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
+            PriceGuardApp.MODE_SYSTEM
+        }
+
+        R.id.rb_light -> {
+            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
+            PriceGuardApp.MODE_LIGHT
+        }
+
+        R.id.rb_dark -> {
+            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
+            PriceGuardApp.MODE_DARK
+        }
+
+        else -> {
+            PriceGuardApp.MODE_SYSTEM
+        }
     }
 
     private fun checkDynamicThemeSupport() {


### PR DESCRIPTION
- Resolves part of #197

## 진행 내용

- [x] 다이나믹 테마 적용이 불가능한 OS면 다이나믹 테마 설정 View 비활성화


## 스크린샷 (선택)

왼쪽: 안드로이드 12 이하 디바이스
오른쪽: 안드로이드 14

<img width="595" alt="image" src="https://github.com/boostcampwm2023/and09-PriceGuard/assets/27392567/c84bc910-928b-41b4-8dee-fd23a0b06b93">


