### PR TITLE
상품 최초 등록시 Redis ttl 제거, tracking cache 순서 재구성 기능 누락 추가, targetPrice 최대값 설정

### DIFF
--- a/backend/src/cache/cache.service.ts
+++ b/backend/src/cache/cache.service.ts
@@ -98,6 +98,10 @@ export class CacheService {
         return this.trackingProductCache.get(key);
     }
 
+    getAllTrackingProduct() {
+        return this.trackingProductCache.getAll();
+    }
+
     addValueTrackingProduct(key: string, value: TrackingProduct) {
         this.trackingProductCache.addValue(key, value);
     }

--- a/backend/src/cache/tracking.cache.ts
+++ b/backend/src/cache/tracking.cache.ts
@@ -20,6 +20,7 @@ export class TrackingProductCache {
         this.delete(key);
         const node = new CacheNode(key, value);
         this.add(node);
+        this.hashMap.set(key, node);
         if (this.count > this.maxSize) {
             const oldestNode = this.head.next;
             this.remove(oldestNode);
@@ -32,7 +33,6 @@ export class TrackingProductCache {
         node.next = this.tail;
         node.prev = prev;
         this.tail.prev = node;
-        this.hashMap.set(node.key, node);
         this.count++;
     }
 
@@ -40,6 +40,7 @@ export class TrackingProductCache {
         const node = this.hashMap.get(key);
         if (node) {
             this.remove(node);
+            this.hashMap.delete(key);
         }
     }
 
@@ -47,7 +48,6 @@ export class TrackingProductCache {
         const { prev, next } = node;
         prev.next = next;
         next.prev = prev;
-        this.hashMap.delete(node.key);
         this.count--;
     }
 
@@ -67,7 +67,12 @@ export class TrackingProductCache {
 
     get(key: string): TrackingProduct[] | null {
         const node = this.hashMap.get(key);
-        return node ? node.value : null;
+        if (node) {
+            this.remove(node);
+            this.add(node);
+            return node.value;
+        }
+        return null;
     }
 
     getAll() {
@@ -84,6 +89,8 @@ export class TrackingProductCache {
         const node = this.hashMap.get(key);
         if (node) {
             node.value.push(value);
+            this.remove(node);
+            this.add(node);
         }
     }
 
@@ -93,6 +100,8 @@ export class TrackingProductCache {
             node.value = node.value.filter((product) => {
                 return product.productId !== value.productId;
             });
+            this.remove(node);
+            this.add(node);
         }
     }
 
@@ -105,6 +114,8 @@ export class TrackingProductCache {
                     return false;
                 }
             });
+            this.remove(node);
+            this.add(node);
         }
     }
 

--- a/backend/src/constants.ts
+++ b/backend/src/constants.ts
@@ -39,3 +39,4 @@ export const TWENTY_MIN_TO_SEC = 20 * 60;
 export const TWO_WEEKS_TO_SEC = 2 * 7 * 24 * 60 * 60;
 export const TWO_MONTHS_TO_SEC = 61 * 24 * 60 * 60;
 export const MAX_TRACKING_PRODUCT_CACHE = parseInt(process.env.MAX_TRACKING_PRODUCT_CACHE || '30');
+export const MAX_TARGET_PRICE = 999999999;

--- a/backend/src/dto/product.add.dto.ts
+++ b/backend/src/dto/product.add.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsString, Max } from 'class-validator';
+import { MAX_TARGET_PRICE } from 'src/constants';
 
 export class ProductAddDto {
     @ApiProperty({
@@ -16,6 +17,7 @@ export class ProductAddDto {
         required: true,
     })
     @IsNumber()
+    @Max(MAX_TARGET_PRICE)
     @IsNotEmpty()
     targetPrice: number;
 }

--- a/backend/src/product/product.service.ts
+++ b/backend/src/product/product.service.ts
@@ -12,7 +12,7 @@ import { InjectModel } from '@nestjs/mongoose';
 import { ProductPrice } from 'src/schema/product.schema';
 import { Model } from 'mongoose';
 import { PriceDataDto } from 'src/dto/price.data.dto';
-import { MAX_TRACKING_RANK, NINETY_DAYS, THIRTY_DAYS, TWENTY_MIN_TO_SEC } from 'src/constants';
+import { MAX_TRACKING_RANK, NINETY_DAYS, THIRTY_DAYS } from 'src/constants';
 import { ProductRankCacheDto } from 'src/dto/product.rank.cache.dto';
 import Redis from 'ioredis';
 import { InjectRedis } from '@songkeys/nestjs-redis';
@@ -265,8 +265,6 @@ export class ProductService {
                 isSoldOut: productInfo.isSoldOut,
                 lowestPrice: productInfo.productPrice,
             }),
-            'EX',
-            TWENTY_MIN_TO_SEC,
         );
         this.productPriceModel.create(updatedDataInfo);
         return product;


### PR DESCRIPTION
## 진행 내용

- [x] 상품 최초 등록시 Redis ttl 제거
- [x] tracking cache의 데이터가 수정되었을 때 LRU로 순서를 재구성하는 기능이 누락되었던 부분을 추가
- [x] 트래킹 상품 targetPrice의 최대값을 10억 미만으로 설정
