### PR TITLE
[상품 추가 화면] 가격 범위가 0~999999999 사이에서 설정되도록 수정

### DIFF
--- a/android/app/src/main/java/app/priceguard/ui/additem/setprice/SetTargetPriceFragment.kt
+++ b/android/app/src/main/java/app/priceguard/ui/additem/setprice/SetTargetPriceFragment.kt
@@ -123,14 +123,18 @@ class SetTargetPriceFragment : Fragment() {
 
     private fun updateTargetPriceUI(it: Editable?) {
         if (binding.etTargetPrice.isFocused) {
-            val targetPrice = if (it.toString().matches("^\\d+\$".toRegex())) {
-                it.toString().toFloat()
+            val targetPrice = if (it.toString().matches("^\\d{1,9}$".toRegex())) {
+                it.toString().toInt()
+            } else if (it.toString().isEmpty()) {
+                binding.etTargetPrice.setText(getString(R.string.min_price))
+                0
             } else {
-                0F
+                binding.etTargetPrice.setText(getString(R.string.max_price))
+                999999999
             }
 
-            setTargetPriceViewModel.updateTargetPrice(targetPrice.toInt())
-            binding.updateSlideValueWithPrice(targetPrice)
+            setTargetPriceViewModel.updateTargetPrice(targetPrice)
+            binding.updateSlideValueWithPrice(targetPrice.toFloat())
         }
     }
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -130,4 +130,6 @@
     <string name="target_price_80">현재 가격의 80%</string>
     <string name="lowest_price_info">역대 최저가 %s</string>
     <string name="target_price_info">목표 가격 %s 으로 설정됨</string>
+    <string name="min_price">0</string>
+    <string name="max_price">999999999</string>
 </resources>


### PR DESCRIPTION
## 진행 내용

- [x] 가격 범위가 0~999999999 사이에서 설정되도록 수정
- [x] UI 상에서 해당 범위를 넘어가는 입력이 발생하면 고정값 적용(0, 999999999)


## 스크린샷 (선택)

https://github.com/boostcampwm2023/and09-PriceGuard/assets/37584805/2e2037ae-36bf-4f75-b136-652f40093665

