### PR TITLE
[푸쉬 알람] 앱이 Foreground 상태에서도 알람을 제대로 받도록 변경

### DIFF
--- a/android/app/src/main/java/app/priceguard/service/PriceGuardFirebaseMessagingService.kt
+++ b/android/app/src/main/java/app/priceguard/service/PriceGuardFirebaseMessagingService.kt
@@ -1,11 +1,111 @@
 package app.priceguard.service
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.drawable.Drawable
+import android.media.RingtoneManager
+import android.net.Uri
+import android.os.Build
 import android.util.Log
+import androidx.core.app.NotificationCompat
+import app.priceguard.R
+import app.priceguard.ui.detail.DetailActivity
+import com.bumptech.glide.Glide
+import com.bumptech.glide.request.target.CustomTarget
+import com.bumptech.glide.request.transition.Transition
 import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
 
 class PriceGuardFirebaseMessagingService : FirebaseMessagingService() {
     // Init 시에도 호출됨
     override fun onNewToken(token: String) {
         Log.d("PriceGuardFirebaseMessagingService", "Refreshed token: $token")
+    }
+
+    override fun onMessageReceived(message: RemoteMessage) {
+        super.onMessageReceived(message)
+        message.notification?.let {
+            sendNotification(
+                it.title ?: return,
+                it.body ?: return,
+                it.imageUrl ?: return,
+                message.data["productCode"] ?: return
+            )
+        }
+    }
+
+    private fun sendNotification(title: String, body: String, imageUrl: Uri, data: String) {
+        val intent = Intent(this, DetailActivity::class.java)
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        intent.putExtra("productCode", data)
+        intent.putExtra("directed", true)
+
+        val requestCode = getRequestCode()
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            requestCode,
+            intent,
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            } else {
+                PendingIntent.FLAG_UPDATE_CURRENT
+            }
+        )
+
+        Glide.with(applicationContext)
+            .asBitmap()
+            .load(imageUrl)
+            .into(object : CustomTarget<Bitmap>() {
+                override fun onResourceReady(resource: Bitmap, transition: Transition<in Bitmap>?) {
+                    buildNotification(title, body, resource, pendingIntent, requestCode)
+                }
+
+                override fun onLoadCleared(placeholder: Drawable?) {}
+            })
+    }
+
+    private fun buildNotification(
+        title: String,
+        body: String,
+        image: Bitmap,
+        pendingIntent: PendingIntent,
+        requestCode: Int
+    ) {
+        val channelId = getString(R.string.priceguard_push_alarm_channel)
+        val defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
+        val notificationBuilder = NotificationCompat.Builder(this, channelId)
+            .setSmallIcon(R.drawable.ic_priceguard_notification)
+            .setContentTitle(title)
+            .setContentText(body)
+            .setAutoCancel(true)
+            .setSound(defaultSoundUri)
+            .setLargeIcon(image)
+            .setStyle(NotificationCompat.BigPictureStyle().bigPicture(image))
+            .setContentIntent(pendingIntent)
+
+        val notificationManager =
+            getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        val channel = NotificationChannel(
+            channelId,
+            "PriceGuard Channel Title",
+            NotificationManager.IMPORTANCE_DEFAULT
+        )
+        notificationManager.createNotificationChannel(channel)
+
+        notificationManager.notify(requestCode, notificationBuilder.build())
+    }
+
+    companion object {
+        private var requestCode = 0
+
+        fun getRequestCode(): Int {
+            requestCode = (requestCode + 1) % 100
+            return requestCode
+        }
     }
 }

--- a/android/app/src/main/java/app/priceguard/ui/util/Dialog.kt
+++ b/android/app/src/main/java/app/priceguard/ui/util/Dialog.kt
@@ -3,7 +3,6 @@ package app.priceguard.ui.util
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
-import app.priceguard.ui.ErrorDialogFragment
 import app.priceguard.ui.data.DialogConfirmAction
 
 fun AppCompatActivity.showConfirmDialog(

--- a/android/app/src/main/java/app/priceguard/ui/util/ErrorDialogFragment.kt
+++ b/android/app/src/main/java/app/priceguard/ui/util/ErrorDialogFragment.kt
@@ -1,4 +1,4 @@
-package app.priceguard.ui
+package app.priceguard.ui.util
 
 import android.app.Dialog
 import android.content.Intent

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -132,4 +132,5 @@
     <string name="target_price_info">목표 가격 %s 으로 설정됨</string>
     <string name="min_price">0</string>
     <string name="max_price">999999999</string>
+    <string name="priceguard_push_alarm_channel">PriceGuard Push Alarm</string>
 </resources>


### PR DESCRIPTION


## 진행 내용

- [x] 앱이 Foreground 상태에서도 알람을 제대로 받도록 변경

만약 올바른 url 혹은 productCode가 오지 않는다면 알람이 발생하지 않도록 설정했습니다.

## 스크린샷 (선택)


https://github.com/boostcampwm2023/and09-PriceGuard/assets/37584805/f1b97860-2bbd-427e-9463-bb559bf3177d

