### PR TITLE
상품 가격 조회 오류 수정

### DIFF
--- a/backend/src/product/product.service.ts
+++ b/backend/src/product/product.service.ts
@@ -236,7 +236,7 @@ export class ProductService {
         const endDate = new Date();
         const startDate = new Date(endDate);
         startDate.setDate(endDate.getDate() - days);
-        const dataInfo = await this.productPriceModel
+        let dataInfo = await this.productPriceModel
             .find({
                 productId: productId,
                 time: {
@@ -245,6 +245,9 @@ export class ProductService {
                 },
             })
             .exec();
+        if (dataInfo.length === 0) {
+            dataInfo = await this.productPriceModel.find({ productId: productId }).sort({ time: -1 }).limit(1).exec();
+        }
         return dataInfo.map(({ time, price, isSoldOut }) => {
             return { time: new Date(time).getTime(), price, isSoldOut };
         });


### PR DESCRIPTION
## 진행 내용
- [x] 상품 가격을 조회할 때, 기간 내 상품 가격이 없으면 발생하는 오류 수정

- Mongo에서 상품 가격을 조회할 때 일정 기간 내의 상품 가격을 조회하는데, 이 때 해당 기간 내에 부합하는 데이터가 없는 경우 서버 내부 로직에서 에러가 발생하였습니다.
- 따라서 해당 상품이 기간 내에 데이터가 없을 경우, 가장 최근 데이터를 다시 조회하도록 수정하였습니다.

## 스크린샷 (선택)

- 사용자가 추적 중인 상품을 조회하였을 때, 특정 상품의 30일 내의 데이터가 Mongo에 존재하지 않아 조회 결과가 빈 배열이 반환되고 이후 서버 내부 로직 상에서 price 정보를 가져오려고 하니 에러가 발생한 로그 입니다.
![가격 조회 오류](https://github.com/boostcampwm2023/and09-PriceGuard/assets/39684860/16fcac82-9311-42e0-9d2b-0ce9435e3bd4)
