### PR TITLE
상품 조회 오류 수정, 푸시 알림 shop 정보 추가, URL 검증 api 분리

### DIFF
--- a/backend/src/constants.ts
+++ b/backend/src/constants.ts
@@ -46,3 +46,5 @@ export const REGEX_SHOP = {
     NaverBrand: /http[s]?:\/\/(?:www\.|m\.)?brand\.naver\.com\/(?:[a-zA-Z0-9_-]+)\/products\/([a-zA-Z0-9_-]+)/,
 } as const;
 export const BROWSER_VERSION_20 = 20;
+export const API_VERSION_NEUTRAL = 0;
+export const API_VERSION_1 = 1;

--- a/backend/src/cron/cron.service.ts
+++ b/backend/src/cron/cron.service.ts
@@ -38,7 +38,7 @@ export class CronService {
         const recentProductInfo = await Promise.all(
             totalProducts.map(async ({ productCode, id, shop }) => {
                 const productInfo = await getProductInfo(shop, productCode);
-                return { ...productInfo, id };
+                return { ...productInfo, productId: id };
             }),
         );
         const productList = recentProductInfo.map((data) => `product:${data.productId}`);

--- a/backend/src/cron/cron.service.ts
+++ b/backend/src/cron/cron.service.ts
@@ -139,19 +139,20 @@ export class CronService {
     }
 
     private getMessage(product: ProductInfoDto, token: string): Message {
+        const { productPrice, productCode, productName, imageUrl, shop } = product;
         return {
             notification: {
                 title: '목표 가격 이하로 내려갔습니다!',
-                body: `${product.productName}의 현재 가격은 ${product.productPrice}원 입니다.`,
+                body: `${productName}의 현재 가격은 ${productPrice}원 입니다.`,
             },
             data: {
-                shop: product.shop,
-                productCode: product.productCode,
+                shop,
+                productCode,
             },
             android: {
                 notification: {
                     channelId: CHANNEL_ID,
-                    imageUrl: product.imageUrl,
+                    imageUrl,
                 },
             },
             token,

--- a/backend/src/product/product.controller.ts
+++ b/backend/src/product/product.controller.ts
@@ -50,6 +50,7 @@ import { User } from 'src/entities/user.entity';
 import { AuthGuard } from '@nestjs/passport';
 import { HttpExceptionFilter } from 'src/exceptions/http.exception.filter';
 import { ExpiredTokenError } from 'src/dto/auth.swagger.dto';
+import { API_VERSION_1, API_VERSION_NEUTRAL } from 'src/constants';
 
 @ApiBearerAuth()
 @ApiHeader({
@@ -71,8 +72,32 @@ export class ProductController {
     @ApiBadRequestResponse({ type: UrlError, description: '유효하지 않은 링크' })
     @Post('/verify')
     async verifyUrl(@Body() productUrlDto: ProductUrlDto): Promise<VerifyUrlSuccess> {
-        const { productName, productCode, productPrice, shop, imageUrl } =
-            await this.productService.verifyUrl(productUrlDto);
+        const { productName, productCode, productPrice, shop, imageUrl } = await this.productService.verifyUrl(
+            productUrlDto,
+            API_VERSION_NEUTRAL,
+        );
+        return {
+            statusCode: HttpStatus.OK,
+            message: '상품 URL 검증 성공',
+            productCode,
+            productName,
+            productPrice,
+            shop,
+            imageUrl,
+        };
+    }
+
+    @ApiOperation({ summary: 'SmartStore가 추가된 상품 URL 검증 API', description: '상품 URL을 검증한다' })
+    @ApiBody({ type: ProductUrlDto })
+    @ApiOkResponse({ type: VerifyUrlSuccess, description: '상품 URL 검증 성공' })
+    @ApiBadRequestResponse({ type: UrlError, description: '유효하지 않은 링크' })
+    @Post('/verify')
+    @Version('1')
+    async verifyUrlV1(@Body() productUrlDto: ProductUrlDto): Promise<VerifyUrlSuccess> {
+        const { productName, productCode, productPrice, shop, imageUrl } = await this.productService.verifyUrl(
+            productUrlDto,
+            API_VERSION_1,
+        );
         return {
             statusCode: HttpStatus.OK,
             message: '상품 URL 검증 성공',

--- a/backend/src/product/product.service.ts
+++ b/backend/src/product/product.service.ts
@@ -31,9 +31,9 @@ export class ProductService {
         private cacheService: CacheService,
     ) {}
 
-    async verifyUrl(productUrlDto: ProductUrlDto): Promise<ProductInfoDto> {
+    async verifyUrl(productUrlDto: ProductUrlDto, apiVersion: number): Promise<ProductInfoDto> {
         const { productUrl } = productUrlDto;
-        const { shop, productCode } = identifyProductByUrl(productUrl);
+        const { shop, productCode } = identifyProductByUrl(productUrl, apiVersion);
         return await getProductInfo(shop, productCode);
     }
 

--- a/backend/src/utils/product.info.ts
+++ b/backend/src/utils/product.info.ts
@@ -1,6 +1,13 @@
 import { HttpException, HttpStatus } from '@nestjs/common';
 import { ProductInfoDto } from 'src/dto/product.info.dto';
-import { BASE_URL_11ST, BROWSER_VERSION_20, OPEN_API_KEY_11ST, REGEX_SHOP } from 'src/constants';
+import {
+    API_VERSION_1,
+    API_VERSION_NEUTRAL,
+    BASE_URL_11ST,
+    BROWSER_VERSION_20,
+    OPEN_API_KEY_11ST,
+    REGEX_SHOP,
+} from 'src/constants';
 import { JSDOM } from 'jsdom';
 import * as convert from 'xml-js';
 import * as iconv from 'iconv-lite';
@@ -124,16 +131,18 @@ export function createUrl(shop: string, productCode: string) {
     }
 }
 
-export function identifyProductByUrl(productUrl: string): ProductIdentifierDto {
+export function identifyProductByUrl(productUrl: string, version: number): ProductIdentifierDto {
     let matchList = null;
-    if ((matchList = productUrl.match(REGEX_SHOP['11ST']))) {
+    if (version === API_VERSION_NEUTRAL && (matchList = productUrl.match(REGEX_SHOP['11ST']))) {
         return { shop: '11번가', productCode: matchList[1] };
     }
-    if (
-        (matchList = productUrl.match(REGEX_SHOP.NaverBrand)) ||
-        (matchList = productUrl.match(REGEX_SHOP.NaverSmartStore))
-    ) {
-        return { shop: 'SmartStore', productCode: matchList[1] };
+    if (version >= API_VERSION_1) {
+        if (
+            (matchList = productUrl.match(REGEX_SHOP.NaverBrand)) ||
+            (matchList = productUrl.match(REGEX_SHOP.NaverSmartStore))
+        ) {
+            return { shop: 'SmartStore', productCode: matchList[1] };
+        }
     }
     throw new HttpException('URL이 유효하지 않습니다.', HttpStatus.BAD_REQUEST);
 }


### PR DESCRIPTION
## 진행 내용

-[x] 상품 조회 오류 수정 
-[x] 푸시 알림 shop 정보 추가 
-[x] URL 검증 api 분리

- cron 과정에서 변수 명이 불일치 하여 오류가 발생하는 이슈를 수정하였습니다.
-  푸시 알림에서도 11번가와 SmartStore를 구분하기 위해 shop 정보를 추가하였습니다.
-  URL 검증 과정에서 SmartStore를 지원하지 않는 어플에서 SmartStore 상품을 등록하는 경우, 11번가와 상품코드가 겹치면 잘 못 등록되는 오류가 있었습니다.
-  해당 문제로 인해 검증 URL도 버전을 분리하였습니다.
