### PR TITLE
Release 파일을 App Bundle 형식으로 변경

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -7,7 +7,7 @@ on:
     
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -41,4 +41,4 @@ jobs:
         serviceCredentialsFileContent: ${{ secrets.FIREBASE_APP_DISTRIBUTION }}
         groups: tester
         releaseNotesFile: android/release_notes.txt
-        file: android/app/build/outputs/apk/release/app-release.apk
+        file: android/app/build/outputs/bundle/release/app-release.aab


### PR DESCRIPTION
## 진행 내용

- [x] App bundle로 배포하게끔 workflow 변경


## 스크린샷 (선택)

Firebase App Distribution -> Play Store Automatic Export ([link](https://firebase.google.com/docs/app-distribution/android/distribute-console?apptype=aab))

<img width="1145" alt="image" src="https://github.com/boostcampwm2023/and09-PriceGuard/assets/27392567/79cf0c89-5a93-4a4d-a881-5804a47cef3c">
