### PR TITLE
상품 이름 및 이미지 갱신 추가, 품절 상품 알림 제외

### DIFF
--- a/backend/src/cron/cron.service.ts
+++ b/backend/src/cron/cron.service.ts
@@ -62,12 +62,10 @@ export class CronService {
         totalProducts.sort((a, b) => a.id.localeCompare(b.id));
         recentProductInfo.sort((a, b) => a.productId.localeCompare(b.productId));
         const infoUpdatedProducts = totalProducts.filter((product, idx) => {
-            if (product.productName !== recentProductInfo[idx].productName) {
-                product.productName = recentProductInfo[idx].productName;
-                return true;
-            }
-            if (product.imageUrl !== recentProductInfo[idx].imageUrl) {
-                product.imageUrl = recentProductInfo[idx].imageUrl;
+            const recentInfo = recentProductInfo[idx];
+            if (product.productName !== recentInfo.productName || product.imageUrl !== recentInfo.imageUrl) {
+                product.productName = recentInfo.productName;
+                product.imageUrl = recentInfo.imageUrl;
                 return true;
             }
         });


### PR DESCRIPTION
## 진행 내용

- [x] 상품 정보 갱신 시, 상품 이름과 이미지가 변경되는 경우에도 정보를 업데이트 하는 기능 추가
- [x] 품절 상품은 알림 제외

- 기존의 경우 상품 정보 갱신 시, 가격과 품절 여부만 갱신확인하였습니다
- 상품 이름과 이미지 URL이 변경되는 경우를 반영하기 위한 기능을 추가하였습니다.
- 위의 경우 추적 상품 캐시도 업데이트 되도록 하였습니다.
- 품절 상품의 경우, 가격이 목표 가격에 도달하여도 알림을 보내지 않도록 하였습니다.


