### PR TITLE
이메일 인증 여부 API 요청 방식 변경, 회원 가입 API 버전 분리, 이메일 인증 DB 반영

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -69,6 +69,7 @@ export class AuthController {
     @Post('/verify/email')
     async verifyEmail(@Body() verifyEmailDto: VerifyEmailDto) {
         await this.authService.verifyEmail(verifyEmailDto.email, verifyEmailDto.verificationCode);
+        await this.authService.verifyUserByEmail(verifyEmailDto.email);
         const verifyToken = await this.authService.getVerifyToken(verifyEmailDto.email);
         return { statusCode: HttpStatus.OK, message: '이메일 인증 성공', verifyToken };
     }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -76,6 +76,10 @@ export class AuthService {
         }
     }
 
+    async verifyUserByEmail(email: string) {
+        await this.usersService.verifyUserByEmail(email);
+    }
+
     async getVerifyToken(email: string) {
         const verifyToken = this.jwtService.sign({ email }, { secret: VERIFY_TOKEN_SECRETS, expiresIn: '5m' });
         return verifyToken;

--- a/backend/src/dto/user.dto.ts
+++ b/backend/src/dto/user.dto.ts
@@ -25,4 +25,6 @@ export class UserDto {
     })
     @IsString()
     password: string;
+
+    verified?: boolean;
 }

--- a/backend/src/entities/user.entity.ts
+++ b/backend/src/entities/user.entity.ts
@@ -23,7 +23,7 @@ export class User extends BaseEntity {
     @Column({ default: 'tier1', type: 'varchar', length: 36, nullable: false })
     grade: string;
 
-    @Column({ default: true, type: 'boolean', nullable: false })
+    @Column({ default: false, type: 'boolean', nullable: false })
     verified: boolean;
 
     @OneToMany(() => TrackingProduct, (trackingProduct) => trackingProduct.userId)

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -139,13 +139,19 @@ export class UsersController {
         summary: '사용자 이메일 인증 여부 확인 API',
         description: '사용자 이메일이 인증되어 있는지 알려준다.',
     })
+    @ApiHeader({
+        name: 'Authorization Bearer Token',
+        description: 'accessToken',
+    })
     @ApiOkResponse({ type: CheckEmailVerificatedSuccess, description: '이메일 인증 코드 발송 성공' })
     @ApiBadRequestResponse({ type: RequestError, description: '잘못된 요청입니다.' })
-    @ApiNotFoundResponse({ type: EmailNotFound, description: '해당 이메일을 찾을 수 없음' })
-    @ApiBody({ type: UserEmailDto })
+    @ApiNotFoundResponse({ type: EmailNotFound, description: '해당 이메일의 사용자를 찾을 수 없음' })
+    @ApiUnauthorizedResponse({ type: UnauthorizedRequest, description: '승인되지 않은 요청' })
+    @ApiGoneResponse({ type: ExpiredTokenError, description: 'accessToken 만료' })
+    @UseGuards(AuthGuard('access'))
     @Get('email/is-verified')
-    async checkEmailVarifacted(@Body() userEmailDto: UserEmailDto) {
-        const verified = await this.userService.checkEmailVarifacted(userEmailDto.email);
+    async checkEmailVarifacted(@Req() req: Request & { user: User }) {
+        const verified = await this.userService.checkEmailVarifacted(req.user.email);
         return { statusCode: HttpStatus.OK, verified, message: '사용자 이메일 인증 여부 조회 성공' };
     }
 

--- a/backend/src/user/user.repository.ts
+++ b/backend/src/user/user.repository.ts
@@ -14,10 +14,10 @@ export class UsersRepository extends Repository<User> {
         super(repository.target, repository.manager, repository.queryRunner);
     }
     async createUser(userDto: UserDto): Promise<User> {
-        const { email, userName, password } = userDto;
+        const { email, userName, password, verified } = userDto;
         const salt = await bcrypt.genSalt();
         const hashedPassword = await bcrypt.hash(password, salt);
-        const user = User.create({ email, userName, password: hashedPassword });
+        const user = User.create({ email, userName, password: hashedPassword, verified });
         await user.save();
         return user;
     }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -93,4 +93,13 @@ export class UsersService {
         user.password = hashedPassword;
         await this.usersRepository.save(user);
     }
+
+    async verifyUserByEmail(email: string): Promise<void> {
+        const user = await this.findUserByEmail(email);
+        if (!user) {
+            throw new HttpException('해당 이메일의 사용자를 찾을 수 없습니다.', HttpStatus.NOT_FOUND);
+        }
+        user.verified = true;
+        await this.usersRepository.save(user);
+    }
 }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -21,10 +21,7 @@ export class UsersService {
         private authService: AuthService,
     ) {}
 
-    async registerUser(userRegisterDto: UserRegisterDto): Promise<User> {
-        const { userName, email, password, verificationCode } = userRegisterDto;
-        await this.authService.verifyEmail(email, verificationCode);
-        const userDto: UserDto = { userName, email, password };
+    async registerUser(userDto: UserDto): Promise<User> {
         try {
             return await this.usersRepository.createUser(userDto);
         } catch (error) {
@@ -36,6 +33,13 @@ export class UsersService {
             }
             throw new HttpException('Error creating user', HttpStatus.INTERNAL_SERVER_ERROR);
         }
+    }
+
+    async registerUserV1(userRegisterDto: UserRegisterDto): Promise<User> {
+        const { userName, email, password, verificationCode } = userRegisterDto;
+        await this.authService.verifyEmail(email, verificationCode);
+        const userDto: UserDto = { userName, email, password, verified: true };
+        return this.registerUser(userDto);
     }
 
     async findUserByEmail(email: string): Promise<User | null> {


### PR DESCRIPTION
## 진행 내용
- [x] 이메일 인증 여부 API 요청 방식 변경 
- [x] 회원 가입 API 버전 분리
- [x] 이메일 인증 시, 사용자 DB 반영

- 사용자의 이메일이 인증되어 있는지 확인하는 API에 대하여 요청 방식을 accessToken으로 요청하도록 변경하였습니다.
- 회원 가입 API에 대하여, 기존 앱에 대한 회원 가입 기능을 유지하기 위해 API 버전을 분리하였습니다.
- 이메일로 전송된 인증 코드를 검증하는 경우, 사용자를 인증된 사용자로 판단하여 DB에 반영되도록 하였습니다.

