### PR TITLE
DB 서버 이전으로 이한 typeorm연결 설정 변경

### DIFF
--- a/backend/src/configs/typeorm.config.ts
+++ b/backend/src/configs/typeorm.config.ts
@@ -10,7 +10,4 @@ export const TypeOrmConfig: TypeOrmModuleOptions = {
     database: DB_NAME,
     entities: ['dist/**/*.entity{.ts,.js}'],
     synchronize: NODE_ENV === 'dev',
-    ssl: {
-        rejectUnauthorized: NODE_ENV === 'prod',
-    },
 };


### PR DESCRIPTION
## 진행 내용

- [x] DB 서버 이전으로 이한 typeorm연결 설정 변경

- DB 서버를 planetscale에서 OCI의 private subnet으로 이전함에 따라, planetscale에 연결하기 위해 필요했던 ssl 연결 설정을 제거하였습니다.

